### PR TITLE
Fix assertion failure on too small ROMs.

### DIFF
--- a/libgambatte/src/mem/cartridge.cpp
+++ b/libgambatte/src/mem/cartridge.cpp
@@ -275,13 +275,14 @@ bool Cartridge::loadROM(const void *romdata, unsigned romsize, const bool forceD
 
 bool Cartridge::loadROM(File &rom, const bool forceDmg, const bool multiCartCompat) {
 	
+	if (rom.size() < 0x4000) return 1;
+	
 	unsigned rambanks = 1;
 	unsigned rombanks = 2;
 	bool cgb = false;
 
 	{
 		unsigned char header[0x150];
-		if (rom.size() < sizeof(header)) return 1;
 		rom.read(reinterpret_cast<char*>(header), sizeof(header));
 
 		switch (header[0x0147]) {


### PR DESCRIPTION
For example ROMs of size 0, or files that don't exist.
