### PR TITLE
Backport 'better lyc trigger inhibition hypothesis with evidence' + 2 related commits

### DIFF
--- a/libgambatte/src/video.h
+++ b/libgambatte/src/video.h
@@ -114,7 +114,11 @@ class LCD
             lyReg = ppu_.lyCounter().ly();
 
             if (lyReg == 153) {
-               lyReg = 0;
+               if (isDoubleSpeed()) {
+                  if (ppu_.lyCounter().time() - cycleCounter <= 456 * 2 - 8)
+                     lyReg = 0;
+               } else
+                  lyReg = 0;
             } else if (ppu_.lyCounter().time() - cycleCounter <= 4)
                ++lyReg;
          }


### PR DESCRIPTION
Backport 'm0 irq inhibits lycirq trigger.' - https://github.com/sinamas/gambatte/commit/5d469bd699541edb24a6b48b1d1419df410172c8
Backport 'plug gaping hole in lyc99 flag read behavior.' - https://github.com/sinamas/gambatte/commit/a92ae38c77644ad7a0b3571b362a77946ff42714
Backport 'better lyc trigger inhibition hypothesis with evidence.' - https://github.com/sinamas/gambatte/commit/12a10f63f2571481e80facacca0796efc8465204