### PR TITLE
Fix DK94 issue with bootloader enabled

### DIFF
--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -70,7 +70,7 @@ void GB::Priv::full_init() {
       // the hw registers must be zeroed out to prevent the logo from being garbled
       std::memset((void*)(ioamhram + 0x100), 0x00, 0x100);
       //init values taken from SameBoy
-      ioamhram[0x100] = 0x0F;//joypad initial value
+      ioamhram[0x100] = 0xCF;//joypad initial value
       ioamhram[0x102] = serialctrl;//serialctrl
       ioamhram[0x148] = 0xFC;//object palette 0
       ioamhram[0x149] = 0xFC;//object palette 1


### PR DESCRIPTION
If I'm reading the comment from guicrith right:
https://forums.libretro.com/t/is-there-a-game-boy-color-core-s-that-support-the-bios-boot/5859/62

The correct start value should be 0xCF instead of 0x0F