### PR TITLE
Make it load palettes only when it makes sense

### DIFF
--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -44,7 +44,9 @@ public:
       FORCE_DMG        = 1, /**< Treat the ROM as not having CGB support regardless of what its header advertises. */
       GBA_CGB          = 2, /**< Use GBA intial CPU register values when in CGB mode. */
       MULTICART_COMPAT = 4,  /**< Use heuristics to detect and support some multicart MBCs disguised as MBC1. */
-      FORCE_CGB        = 8
+      FORCE_CGB        = 8,
+      USING_GB_BIOS    = 16,
+      USING_CGB_BIOS   = 32
 	};
 	
    int load(const void *romdata, unsigned size, unsigned flags = 0);
@@ -107,7 +109,16 @@ public:
 
 	/** Returns true if DMG mode was forced **/
 	bool isGbForced() const;
-	
+
+	/** Returns true if CGB mode was forced **/
+	bool isCgbForced() const;
+
+	/** Returns true if using real GB BIOS **/
+	bool isUsingGbBios() const;
+
+	/** Returns true if using real CGB BIOS **/
+	bool isUsingCgbBios() const;
+
 	/** Returns true if a ROM image is loaded. */
 	bool isLoaded() const;
 	

--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -45,7 +45,7 @@ public:
       GBA_CGB          = 2, /**< Use GBA intial CPU register values when in CGB mode. */
       MULTICART_COMPAT = 4,  /**< Use heuristics to detect and support some multicart MBCs disguised as MBC1. */
       FORCE_CGB        = 8,
-      USING_GB_BIOS    = 16,
+      USING_DMG_BIOS   = 16,
       USING_CGB_BIOS   = 32
 	};
 	
@@ -108,13 +108,13 @@ public:
 	bool isCgb() const;
 
 	/** Returns true if DMG mode was forced **/
-	bool isGbForced() const;
+	bool isDmgForced() const;
 
 	/** Returns true if CGB mode was forced **/
 	bool isCgbForced() const;
 
 	/** Returns true if using real GB BIOS **/
-	bool isUsingGbBios() const;
+	bool isUsingDmgBios() const;
 
 	/** Returns true if using real CGB BIOS **/
 	bool isUsingCgbBios() const;

--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -104,6 +104,9 @@ public:
 	
 	/** Returns true if the currently loaded ROM image is treated as having CGB support. */
 	bool isCgb() const;
+
+	/** Returns true if DMG mode was forced **/
+	bool isGbForced() const;
 	
 	/** Returns true if a ROM image is loaded. */
 	bool isLoaded() const;

--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -570,16 +570,28 @@ static void check_variables(void)
    }
 #endif
 
+   // there's no colorization in real GB, this avoids having a GBC game with GB palettes too
+   if (gb.isGbForced() == true)
+      return;
+
+   // if it's using real GB BIOS, there's no sense to see the GB bootloader in the screen & colorization all together
+   bool has_gb_bootloader = file_present_in_system("gb_bios.bin");
+   bool use_bootloader = false;
+   var.key = "gambatte_gb_bootloaderenabled";
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "enabled"))
+         use_bootloader = true;
+   }
+   if (!gb.isCgb() && has_gb_bootloader && use_bootloader)
+      return;
+
    var.key = "gambatte_gb_colorization";
 
    if (!environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) || !var.value)
       return;
    
    if (gb.isCgb())
-      return;
-
-   // there's no colorization in real GB, this avoids having a GBC game with GB palettes too
-   if (gb.isGbForced() == true)
       return;
 
    // else it is a GB-mono game -> set a color palette

--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -281,7 +281,7 @@ void retro_set_environment(retro_environment_t cb)
       { "gambatte_gb_colorization", "GB Colorization; disabled|auto|internal|custom" },
       { "gambatte_gb_internal_palette", "Internal Palette; GBC - Blue|GBC - Brown|GBC - Dark Blue|GBC - Dark Brown|GBC - Dark Green|GBC - Grayscale|GBC - Green|GBC - Inverted|GBC - Orange|GBC - Pastel Mix|GBC - Red|GBC - Yellow|Special 1|Special 2|Special 3" },
       { "gambatte_gbc_color_correction", "Color correction; enabled|disabled" },
-      { "gambatte_gb_hwmode", "Emulated hardware; Auto|GB|GBC|GBA" },
+      { "gambatte_gb_hwmode", "Emulated hardware (restart); Auto|GB|GBC|GBA" },
       { "gambatte_gb_bootloaderenabled", "Use official bootloader; enabled|disabled" },
 #ifdef HAVE_NETWORK
       { "gambatte_gb_link_mode", "GameBoy Link Mode; Not Connected|Network Server|Network Client" },
@@ -578,6 +578,10 @@ static void check_variables(void)
    if (gb.isCgb())
       return;
 
+   // there's no colorization in real GB, this avoids having a GBC game with GB palettes too
+   if (gb.isGbForced() == true)
+      return;
+
    // else it is a GB-mono game -> set a color palette
    //bool gb_colorization_old = gb_colorization_enable;
 
@@ -602,8 +606,8 @@ static void check_variables(void)
         gbc_bios_palette = const_cast<unsigned short*>(findGbcTitlePal(internal_game_name));
         if (!gbc_bios_palette)
         {
-           // no custom palette found, load the default (blue)
-           gbc_bios_palette = const_cast<unsigned short*>(findGbcDirPal("GBC - Blue"));
+           // no custom palette found, load the default (Dark Green, such as GBC BIOS)
+           gbc_bios_palette = const_cast<unsigned short*>(findGbcDirPal("GBC - Dark Green"));
         }
       break;
         

--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -80,7 +80,7 @@ bool file_present_in_system(std::string fname)
 bool get_bootloader_from_file(void* userdata, bool isgbc, uint8_t* data, uint32_t buf_size)
 {
    struct retro_variable var = {0};
-   var.key = "gambatte_gb_bootloaderenabled";
+   var.key = "gambatte_gb_bootloader";
 
    if (!environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) || !var.value)
       return false;
@@ -282,7 +282,7 @@ void retro_set_environment(retro_environment_t cb)
       { "gambatte_gb_internal_palette", "Internal Palette; GBC - Blue|GBC - Brown|GBC - Dark Blue|GBC - Dark Brown|GBC - Dark Green|GBC - Grayscale|GBC - Green|GBC - Inverted|GBC - Orange|GBC - Pastel Mix|GBC - Red|GBC - Yellow|Special 1|Special 2|Special 3" },
       { "gambatte_gbc_color_correction", "Color correction; enabled|disabled" },
       { "gambatte_gb_hwmode", "Emulated hardware (restart); Auto|GB|GBC|GBA" },
-      { "gambatte_gb_bootloaderenabled", "Use official bootloader; enabled|disabled" },
+      { "gambatte_gb_bootloader", "Use official bootloader; enabled|disabled" },
 #ifdef HAVE_NETWORK
       { "gambatte_gb_link_mode", "GameBoy Link Mode; Not Connected|Network Server|Network Client" },
       { "gambatte_gb_link_network_port", "Network Link Port; 56400|56401|56402|56403|56404|56405|56406|56407|56408|56409|56410|56411|56412|56413|56414|56415|56416|56417|56418|56419|56420" },
@@ -706,7 +706,7 @@ bool retro_load_game(const struct retro_game_info *info)
    
    struct retro_variable var = {0};
    
-   var.key = "gambatte_gb_bootloaderenabled";
+   var.key = "gambatte_gb_bootloader";
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "enabled"))

--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -579,11 +579,11 @@ static void check_variables(void)
       return;
 
    // there's no colorization in real GB, this avoids having a GBC game with GB palettes too
-   if (gb.isGbForced())
+   if (gb.isDmgForced())
       return;
 
    // if it's using real GB BIOS, there's no sense to see the GB bootloader in the screen & colorization all together
-   if (gb.isUsingGbBios())
+   if (gb.isUsingDmgBios())
       return;
 
    // else it is a GB-mono game using HLE BIOS (with gambatte_gb_hwmode Auto, GBC or GBA) -> set a color palette
@@ -737,7 +737,7 @@ bool retro_load_game(const struct retro_game_info *info)
    }
 
    if (has_gb_bootloader && use_bootloader)
-      flags |= gambatte::GB::USING_GB_BIOS;
+      flags |= gambatte::GB::USING_DMG_BIOS;
    if (has_gbc_bootloader && use_bootloader)
       flags |= gambatte::GB::USING_CGB_BIOS;
 

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -30,8 +30,9 @@ struct GB::Priv {
 	CPU cpu;
 	int stateNo;
 	bool gbaCgbMode;
+	bool gbForced;
 	
-	Priv() : stateNo(1), gbaCgbMode(false) {}
+	Priv() : stateNo(1), gbaCgbMode(false), gbForced(false) {}
 
    void full_init();
 };
@@ -107,6 +108,7 @@ int GB::load(const void *romdata, unsigned romsize, const unsigned flags) {
 	
    if (!failed) {
       p_->gbaCgbMode = flags & GBA_CGB;
+      p_->gbForced = flags & FORCE_DMG;
       p_->full_init();
       p_->stateNo = 1;
    }
@@ -116,6 +118,10 @@ int GB::load(const void *romdata, unsigned romsize, const unsigned flags) {
 
 bool GB::isCgb() const {
 	return p_->cpu.isCgb();
+}
+
+bool GB::isGbForced() const {
+	return p_->gbForced;
 }
 
 bool GB::isLoaded() const {

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -30,12 +30,12 @@ struct GB::Priv {
 	CPU cpu;
 	int stateNo;
 	bool gbaCgbMode;
-	bool gbForced;
+	bool dmgForced;
 	bool cgbForced;
-	bool usingGbBios;
+	bool usingDmgBios;
 	bool usingCgbBios;
 	
-	Priv() : stateNo(1), gbaCgbMode(false), gbForced(false), cgbForced(false), usingGbBios(false), usingCgbBios(false) {}
+	Priv() : stateNo(1), gbaCgbMode(false), dmgForced(false), cgbForced(false), usingDmgBios(false), usingCgbBios(false) {}
 
    void full_init();
 };
@@ -111,9 +111,9 @@ int GB::load(const void *romdata, unsigned romsize, const unsigned flags) {
 	
    if (!failed) {
       p_->gbaCgbMode = flags & GBA_CGB;
-      p_->gbForced = flags & FORCE_DMG;
+      p_->dmgForced = flags & FORCE_DMG;
       p_->cgbForced = flags & FORCE_CGB;
-      p_->usingGbBios = flags & USING_GB_BIOS;
+      p_->usingDmgBios = flags & USING_DMG_BIOS;
       p_->usingCgbBios = flags & USING_CGB_BIOS;
       p_->full_init();
       p_->stateNo = 1;
@@ -126,16 +126,16 @@ bool GB::isCgb() const {
 	return p_->cpu.isCgb();
 }
 
-bool GB::isGbForced() const {
-	return p_->gbForced;
+bool GB::isDmgForced() const {
+	return p_->dmgForced;
 }
 
 bool GB::isCgbForced() const {
 	return p_->cgbForced;
 }
 
-bool GB::isUsingGbBios() const {
-	return p_->usingGbBios;
+bool GB::isUsingDmgBios() const {
+	return p_->usingDmgBios;
 }
 
 bool GB::isUsingCgbBios() const {

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -31,8 +31,11 @@ struct GB::Priv {
 	int stateNo;
 	bool gbaCgbMode;
 	bool gbForced;
+	bool cgbForced;
+	bool usingGbBios;
+	bool usingCgbBios;
 	
-	Priv() : stateNo(1), gbaCgbMode(false), gbForced(false) {}
+	Priv() : stateNo(1), gbaCgbMode(false), gbForced(false), cgbForced(false), usingGbBios(false), usingCgbBios(false) {}
 
    void full_init();
 };
@@ -109,6 +112,9 @@ int GB::load(const void *romdata, unsigned romsize, const unsigned flags) {
    if (!failed) {
       p_->gbaCgbMode = flags & GBA_CGB;
       p_->gbForced = flags & FORCE_DMG;
+      p_->cgbForced = flags & FORCE_CGB;
+      p_->usingGbBios = flags & USING_GB_BIOS;
+      p_->usingCgbBios = flags & USING_CGB_BIOS;
       p_->full_init();
       p_->stateNo = 1;
    }
@@ -122,6 +128,18 @@ bool GB::isCgb() const {
 
 bool GB::isGbForced() const {
 	return p_->gbForced;
+}
+
+bool GB::isCgbForced() const {
+	return p_->cgbForced;
+}
+
+bool GB::isUsingGbBios() const {
+	return p_->usingGbBios;
+}
+
+bool GB::isUsingCgbBios() const {
+	return p_->usingCgbBios;
 }
 
 bool GB::isLoaded() const {


### PR DESCRIPTION
Loads palettes only when using HLE BIOS (Auto/GBC/GBA) or forcing GBC/GBA with real bios. Make it works more like real hardware while using real bios.

Avoids weird palettes in GBC games when forcing GB:

![pokemon - gold version usa europe sgb enhanced -170213-015240](https://cloud.githubusercontent.com/assets/5431285/22993880/c7fc1dbe-f3ab-11e6-96cd-d9b27e93b621.png)

Fixed default palette too (Dark Green).