### PR TITLE
Swap these conditions, otherwise Darwin gets matched as win & fails b…

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -11,15 +11,15 @@ filter_out2 = $(call filter_out1,$(call filter_out1,$1))
 # system platform
 ifeq ($(platform),)
    platform = unix
-   ifeq ($(shell uname -a),)
+   ifeq ($(shell uname -s),)
       EXE_EXT = .exe
       platform = win
-   else ifneq ($(findstring MINGW,$(shell uname -a)),)
+   else ifneq ($(findstring MINGW,$(shell uname -s)),)
       platform = win
-   else ifneq ($(findstring win,$(shell uname -a)),)
-      platform = win
-   else ifneq ($(findstring Darwin,$(shell uname -a)),)
+   else ifneq ($(findstring Darwin,$(shell uname -s)),)
       platform = osx
+   else ifneq ($(findstring win,$(shell uname -s)),)
+      platform = win
    endif
 else ifneq (,$(findstring armv,$(platform)))
    override platform += unix


### PR DESCRIPTION
…uild (thanks endrift to point out)

Also use uname -s instead, in case a unix system has 'win' or other word in its hostname