### PR TITLE
alter memory descriptors to accommodate bankswitched RAM size

### DIFF
--- a/libgambatte/libretro-common/include/libretro.h
+++ b/libgambatte/libretro-common/include/libretro.h
@@ -1231,14 +1231,17 @@ struct retro_hw_render_context_negotiation_interface
                                             * recognize or support. Should be set in either retro_init or retro_load_game, but not both.
                                             */
 
-#define RETRO_MEMDESC_CONST     (1 << 0)   /* The frontend will never change this memory area once retro_load_game has returned. */
-#define RETRO_MEMDESC_BIGENDIAN (1 << 1)   /* The memory area contains big endian data. Default is little endian. */
-#define RETRO_MEMDESC_ALIGN_2   (1 << 16)  /* All memory access in this area is aligned to their own size, or 2, whichever is smaller. */
-#define RETRO_MEMDESC_ALIGN_4   (2 << 16)
-#define RETRO_MEMDESC_ALIGN_8   (3 << 16)
-#define RETRO_MEMDESC_MINSIZE_2 (1 << 24)  /* All memory in this region is accessed at least 2 bytes at the time. */
-#define RETRO_MEMDESC_MINSIZE_4 (2 << 24)
-#define RETRO_MEMDESC_MINSIZE_8 (3 << 24)
+#define RETRO_MEMDESC_CONST      (1 << 0)   /* The frontend will never change this memory area once retro_load_game has returned. */
+#define RETRO_MEMDESC_BIGENDIAN  (1 << 1)   /* The memory area contains big endian data. Default is little endian. */
+#define RETRO_MEMDESC_SYSTEM_RAM (1 << 2)   /* The memory area is system RAM.  This is main RAM of the gaming system. */
+#define RETRO_MEMDESC_SAVE_RAM   (1 << 3)   /* The memory area is save RAM. This RAM is usually found on a game cartridge, backed up by a battery. */
+#define RETRO_MEMDESC_VIDEO_RAM  (1 << 4)   /* The memory area is video RAM (VRAM) */
+#define RETRO_MEMDESC_ALIGN_2    (1 << 16)  /* All memory access in this area is aligned to their own size, or 2, whichever is smaller. */
+#define RETRO_MEMDESC_ALIGN_4    (2 << 16)
+#define RETRO_MEMDESC_ALIGN_8    (3 << 16)
+#define RETRO_MEMDESC_MINSIZE_2  (1 << 24)  /* All memory in this region is accessed at least 2 bytes at the time. */
+#define RETRO_MEMDESC_MINSIZE_4  (2 << 24)
+#define RETRO_MEMDESC_MINSIZE_8  (3 << 24)
 struct retro_memory_descriptor
 {
    uint64_t flags;

--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -782,18 +782,19 @@ bool retro_load_game(const struct retro_game_info *info)
    check_variables();
 
    unsigned sramlen = gb.savedata_size();
-   const uint64_t rom = RETRO_MEMDESC_CONST;
+   const uint64_t rom     = RETRO_MEMDESC_CONST;
+   const uint64_t mainram = RETRO_MEMDESC_SYSTEM_RAM;
 
    struct retro_memory_descriptor descs[] =
    {
-      {   0, gb.zeropage_ptr(), 0, 0xFF80,               0, 0, 0x0080,  NULL },
-      {   0, gb.rambank0_ptr(), 0, 0xC000,               0, 0, 0x1000,  NULL },
-      {   0, gb.rambank1_ptr(), 0, 0xD000,               0, 0, 0x1000,  NULL },
-      {   0, gb.savedata_ptr(), 0, 0xA000, (size_t)~0x1FFF, 0, sramlen, NULL },
-      {   0, gb.vram_ptr(),     0, 0x8000,               0, 0, 0x2000,  NULL },
-      {   0, gb.oamram_ptr(),   0, 0xFE00,               0, 0, 0x00A0,  NULL },
-      { rom, gb.rombank0_ptr(), 0, 0x0000,               0, 0, 0x4000,  NULL },
-      { rom, gb.rombank1_ptr(), 0, 0x4000,               0, 0, 0x4000,  NULL },
+      { mainram, gb.rambank0_ptr(), 0, 0xC000,               0, 0, 0x1000,                        NULL },
+      { mainram, gb.rambank1_ptr(), 0, 0xD000,               0, 0, gb.isCgb() ? 0x7000 : 0x1000,  NULL },
+      { mainram, gb.zeropage_ptr(), 0, 0xFF80,               0, 0, 0x0080,                        NULL },
+      {       0, gb.savedata_ptr(), 0, 0xA000, (size_t)~0x1FFF, 0, sramlen,                       NULL },
+      {       0, gb.vram_ptr(),     0, 0x8000,               0, 0, 0x2000,                        NULL },
+      {       0, gb.oamram_ptr(),   0, 0xFE00,               0, 0, 0x00A0,                        NULL },
+      {     rom, gb.rombank0_ptr(), 0, 0x0000,               0, 0, 0x4000,                        NULL },
+      {     rom, gb.rombank1_ptr(), 0, 0x4000,               0, 0, 0x4000,                        NULL },
    };
    
    struct retro_memory_map mmaps =


### PR DESCRIPTION
@leiradel heads up - this is the increase in the memory descriptor "len" to reflect bankswitched RAM