### PR TITLE
Improve colour correction

### DIFF
--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -113,6 +113,7 @@ public:
    size_t stateSize() const;
 
    void setColorCorrection(bool enable);
+   void setColorCorrectionMode(unsigned colorCorrectionMode);
    video_pixel_t gbcToRgb32(const unsigned bgr15);
 
    /** Set Game Genie codes to apply to currently loaded ROM image. Cleared on ROM load.

--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -361,6 +361,7 @@ Special 2|\
 Special 3"
 }, // So many... place on seperate lines for readability...
       { "gambatte_gbc_color_correction", "Color correction; enabled|disabled" },
+      { "gambatte_gbc_color_correction_mode", "Color correction mode; accurate|fast" },
       { "gambatte_gb_hwmode", "Emulated hardware (restart); Auto|GB|GBC|GBA" },
       { "gambatte_gb_bootloader", "Use official bootloader (restart); enabled|disabled" },
 #ifdef HAVE_NETWORK
@@ -604,7 +605,15 @@ static void check_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && !strcmp(var.value, "disabled"))
       colorCorrection=false;
    gb.setColorCorrection(colorCorrection);
-
+   
+   unsigned colorCorrectionMode = 0;
+   var.key   = "gambatte_gbc_color_correction_mode";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value && !strcmp(var.value, "fast")) {
+      colorCorrectionMode = 1;
+   }
+   gb.setColorCorrectionMode(colorCorrectionMode);
+   
    var.key   = "gambatte_up_down_allowed";
    var.value = NULL;
 

--- a/libgambatte/src/gambatte-memory.h
+++ b/libgambatte/src/gambatte-memory.h
@@ -48,6 +48,7 @@ public:
    void *rtcdata_ptr() { return cart_.rtcdata_ptr(); }
    unsigned rtcdata_size() { return cart_.rtcdata_size(); }
    void display_setColorCorrection(bool enable) { lcd_.setColorCorrection(enable); }
+   void display_setColorCorrectionMode(unsigned colorCorrectionMode) { lcd_.setColorCorrectionMode(colorCorrectionMode); }
    video_pixel_t display_gbcToRgb32(const unsigned bgr15) { return lcd_.gbcToRgb32(bgr15); }
    void clearCheats() { cart_.clearCheats(); }
    void *vram_ptr() const { return cart_.vramdata(); }

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -154,6 +154,10 @@ void GB::setColorCorrection(bool enable) {
    p_->cpu.mem_.display_setColorCorrection(enable);
 }
 
+void GB::setColorCorrectionMode(unsigned colorCorrectionMode) {
+   p_->cpu.mem_.display_setColorCorrectionMode(colorCorrectionMode);
+}
+
 video_pixel_t GB::gbcToRgb32(const unsigned bgr15) {
    return p_->cpu.mem_.display_gbcToRgb32(bgr15);
 }

--- a/libgambatte/src/video.h
+++ b/libgambatte/src/video.h
@@ -154,6 +154,7 @@ class LCD
       bool isDoubleSpeed() const { return ppu_.lyCounter().isDoubleSpeed(); }
 
       void setColorCorrection(bool colorCorrection);
+      void setColorCorrectionMode(unsigned colorCorrectionMode);
       video_pixel_t gbcToRgb32(const unsigned bgr15);
    private:
       enum Event { MEM_EVENT, LY_COUNT }; enum { NUM_EVENTS = LY_COUNT + 1 };
@@ -225,6 +226,7 @@ class LCD
       void doCgbSpColorChange(unsigned index, unsigned data, unsigned long cycleCounter);
 
       bool colorCorrection;
+      unsigned colorCorrectionMode;
       void doCgbColorChange(unsigned char *const pdata,
             video_pixel_t *const palette, unsigned index, const unsigned data);
 


### PR DESCRIPTION
This pull request adds a new 'accurate' internal colour correction method derived from Pokefan531's excellent/famous gbc-color shader (https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540/159). The old method has been retained, since it is faster and may still be relevant on ultra low end hardware (3DS, perhaps?). Users may switch between the two via a new 'Color correction mode' core option.

Here are a handful of screenshots to show the difference this makes:

- No colour correction:

<img src="https://user-images.githubusercontent.com/38211560/47094001-3eda1200-d222-11e8-9612-716daf6ddb59.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47094232-b6a83c80-d222-11e8-8c1a-c56fbffe0c5f.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47094237-ba3bc380-d222-11e8-94fc-85ffe610cef6.png" height="144">

- Color correction mode: fast

(note how Pikachu has an orange perma-tan, and the tennis court is entirely the wrong colour)

<img src="https://user-images.githubusercontent.com/38211560/47094322-ea836200-d222-11e8-971d-4d0c0864b616.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47094332-eeaf7f80-d222-11e8-99f3-7ef49c98eefb.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47094343-f2430680-d222-11e8-81a7-26c9929f310e.png" height="144">

- Color correction mode: accurate

<img src="https://user-images.githubusercontent.com/38211560/47094533-4e0d8f80-d223-11e8-8c7e-f000aa96929c.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47094548-52d24380-d223-11e8-96dc-f428bb1c9ac3.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47094551-55cd3400-d223-11e8-9698-e5cd057bc750.png" height="144">

I have also enabled finer control of *when* colour correction should be used. In the existing core, turning colour correction 'on' applies it to everything, which substantially degrades the internal GB and SGB palettes (all of which are designed to be viewed on a normal TV/monitor, rather than the LCD panel of a GBC). This makes the core rather tedious to work with, since you have to create core overrides for each type of game you want to play (or disable internal colour correction entirely, and set up shader overrides for each type of game you want to play...).

This pull request therefore modifies the 'Color correction' core option so it now has three settings:

- GBC only: disables colour correction unless actually running a GBC game, or using an internal GBC palette

- always: the old behaviour of applying colour correction everywhere

- disabled

I hope these additions will make the core much more user friendly. You can now basically set something like:

- GB Colorization: auto

- Internal Palette: GB - Pocket

- Color correction: GBC only

- Color correction mode: accurate

- Emulated hardware (restart): Auto

- Shader: simpletex_lcd

...and every single game will look fantastic with no further user interaction (i.e. no more fiddling around with individual config/shader overrides).