### PR TITLE
Add optional 'dark filter'

### DIFF
--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -114,6 +114,7 @@ public:
 
    void setColorCorrection(bool enable);
    void setColorCorrectionMode(unsigned colorCorrectionMode);
+   void setDarkFilterLevel(unsigned darkFilterLevel);
    video_pixel_t gbcToRgb32(const unsigned bgr15);
 
    /** Set Game Genie codes to apply to currently loaded ROM image. Cleared on ROM load.

--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -362,6 +362,7 @@ Special 3"
 }, // So many... place on seperate lines for readability...
       { "gambatte_gbc_color_correction", "Color correction; GBC only|always|disabled" },
       { "gambatte_gbc_color_correction_mode", "Color correction mode; accurate|fast" },
+      { "gambatte_dark_filter_level", "Dark Filter Level (percent); 0|5|10|15|20|25|30|35|40|45|50" },
       { "gambatte_gb_hwmode", "Emulated hardware (restart); Auto|GB|GBC|GBA" },
       { "gambatte_gb_bootloader", "Use official bootloader (restart); enabled|disabled" },
 #ifdef HAVE_NETWORK
@@ -617,6 +618,15 @@ static void check_variables(void)
       colorCorrectionMode = 1;
    }
    gb.setColorCorrectionMode(colorCorrectionMode);
+   
+   unsigned darkFilterLevel = 0;
+   var.key   = "gambatte_dark_filter_level";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      darkFilterLevel = static_cast<unsigned>(atoi(var.value));
+   }
+   gb.setDarkFilterLevel(darkFilterLevel);
    
    var.key   = "gambatte_up_down_allowed";
    var.value = NULL;

--- a/libgambatte/src/gambatte-memory.h
+++ b/libgambatte/src/gambatte-memory.h
@@ -49,6 +49,7 @@ public:
    unsigned rtcdata_size() { return cart_.rtcdata_size(); }
    void display_setColorCorrection(bool enable) { lcd_.setColorCorrection(enable); }
    void display_setColorCorrectionMode(unsigned colorCorrectionMode) { lcd_.setColorCorrectionMode(colorCorrectionMode); }
+   void display_setDarkFilterLevel(unsigned darkFilterLevel) { lcd_.setDarkFilterLevel(darkFilterLevel); }
    video_pixel_t display_gbcToRgb32(const unsigned bgr15) { return lcd_.gbcToRgb32(bgr15); }
    void clearCheats() { cart_.clearCheats(); }
    void *vram_ptr() const { return cart_.vramdata(); }

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -158,6 +158,10 @@ void GB::setColorCorrectionMode(unsigned colorCorrectionMode) {
    p_->cpu.mem_.display_setColorCorrectionMode(colorCorrectionMode);
 }
 
+void GB::setDarkFilterLevel(unsigned darkFilterLevel) {
+   p_->cpu.mem_.display_setDarkFilterLevel(darkFilterLevel);
+}
+
 video_pixel_t GB::gbcToRgb32(const unsigned bgr15) {
    return p_->cpu.mem_.display_gbcToRgb32(bgr15);
 }

--- a/libgambatte/src/video.h
+++ b/libgambatte/src/video.h
@@ -155,6 +155,7 @@ class LCD
 
       void setColorCorrection(bool colorCorrection);
       void setColorCorrectionMode(unsigned colorCorrectionMode);
+      void setDarkFilterLevel(unsigned darkFilterLevel);
       video_pixel_t gbcToRgb32(const unsigned bgr15);
    private:
       enum Event { MEM_EVENT, LY_COUNT }; enum { NUM_EVENTS = LY_COUNT + 1 };
@@ -227,8 +228,11 @@ class LCD
 
       bool colorCorrection;
       unsigned colorCorrectionMode;
+      unsigned darkFilterLevel;
       void doCgbColorChange(unsigned char *const pdata,
             video_pixel_t *const palette, unsigned index, const unsigned data);
+
+      void darkenRgb(float &r, float &g, float &b);
 
 };
 


### PR DESCRIPTION
Games written for early non-backlit LCD handhelds often made use of white backgrounds. While these look fine on original hardware, they are generally far too bright when viewed on a modern backlit screen. On most platforms this can be mitigated with some form of LCD shader, but on garbage-tier hardware this is not always an option. This became a real issue while I was testing the core on my 3DS: games like Pokemon, Pokemon Pinball and the original Donkey Kong are just too hard on the eyes to play in comfort for any length of time.

This pull request tries to solve the problem by adding a very simple 'dark filter', which reduces brightness by a configurable percentage. It's kind of analogous to the darkening that Nintendo uses in its Virtual Console titles, only less awful. Instead of a uniform brightness reduction, the 'darkening' is roughly proportional to pixel luminosity - this gets rid of harsh glare without completely butchering image quality (although I would still only recommend using the filter on games with white backgrounds, since there is a small degree of colour mangling).

Here are some screenshots of the filter in action - in each case, the left hand image is 'normal' and the right hand image has a 'dark filter' level of 30% (I guess 15% would be a more typical value, but setting it high makes it easier to see how colours are affected):

<img src="https://user-images.githubusercontent.com/38211560/47300506-842c8400-d614-11e8-8a4f-2c61e2cbd253.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47300510-87c00b00-d614-11e8-9f52-d859682756d5.png" height="144">

<img src="https://user-images.githubusercontent.com/38211560/47301360-a0c9bb80-d616-11e8-83ec-7985d75d7c00.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47301367-a45d4280-d616-11e8-9a2c-d8c8075515c5.png" height="144">

<img src="https://user-images.githubusercontent.com/38211560/47301373-a7583300-d616-11e8-9436-84e3e9402ee1.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47301378-aaebba00-d616-11e8-95f0-8cf18f0e66eb.png" height="144">

<img src="https://user-images.githubusercontent.com/38211560/47301381-ade6aa80-d616-11e8-99e6-d2a45d4748f0.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47301386-b0e19b00-d616-11e8-9f9c-0e1b4c915cf5.png" height="144">

<img src="https://user-images.githubusercontent.com/38211560/47301390-b3dc8b80-d616-11e8-8758-e2af86615d07.png" height="144"><img src="https://user-images.githubusercontent.com/38211560/47301399-b939d600-d616-11e8-9aba-0b29848f68de.png" height="144">







