### PR TITLE
Fix save states

### DIFF
--- a/libgambatte/src/initstate.cpp
+++ b/libgambatte/src/initstate.cpp
@@ -1208,6 +1208,10 @@ void gambatte::setInitState(SaveState &state, bool const cgb, bool const gbaCgbM
 	state.mem.dmaDestination = 0;
 	state.mem.rambank = 0;
 	state.mem.oamDmaPos = 0xFE;
+#ifdef HAVE_NETWORK
+	state.mem.serialize_value = 0xFF;
+	state.mem.serialize_is_fastcgb = false;
+#endif
 	state.mem.IME = false;
 	state.mem.halted = false;
 	state.mem.enableRam = false;

--- a/libgambatte/src/savestate.h
+++ b/libgambatte/src/savestate.h
@@ -77,7 +77,7 @@ struct SaveState {
 		unsigned char oamDmaPos;
 #ifdef HAVE_NETWORK
 		unsigned char serialize_value;
-		unsigned char serialize_is_fastcgb;
+		bool serialize_is_fastcgb;
 #endif
 		bool IME;
 		bool halted;

--- a/libgambatte/src/statesaver.cpp
+++ b/libgambatte/src/statesaver.cpp
@@ -72,6 +72,7 @@ class imemstream
       {
          std::memcpy(data, rd_ptr, size);
          rd_ptr += size;
+         has_read += size;
       }
 
       void ignore(size_t len = 1)
@@ -335,6 +336,10 @@ SaverList::SaverList() {
 	{ static const char label[] = { d,m,a,d,s,t,   NUL }; ADD(mem.dmaDestination); }
 	{ static const char label[] = { r,a,m,b,a,n,k, NUL }; ADD(mem.rambank); }
 	{ static const char label[] = { o,d,m,a,p,o,s, NUL }; ADD(mem.oamDmaPos); }
+#ifdef HAVE_NETWORK
+	{ static const char label[] = { n,e,t,s,v,     NUL }; ADD(mem.serialize_value); }
+	{ static const char label[] = { n,e,t,s,f,c,   NUL }; ADD(mem.serialize_is_fastcgb); }
+#endif
 	{ static const char label[] = { i,m,e,         NUL }; ADD(mem.IME); }
 	{ static const char label[] = { s,r,a,m,o,n,   NUL }; ADD(mem.enableRam); }
 	{ static const char label[] = { r,a,m,b,m,o,d, NUL }; ADD(mem.rambankMode); }
@@ -376,6 +381,7 @@ SaverList::SaverList() {
 	{ static const char label[] = { s,w,p,n,e,g,   NUL }; ADD(spu.ch1.sweep.negging); }
 	{ static const char label[] = { d,u,t,NO1,c,t,r, NUL }; ADD(spu.ch1.duty.nextPosUpdate); }
 	{ static const char label[] = { d,u,t,NO1,p,o,s, NUL }; ADD(spu.ch1.duty.pos); }
+	{ static char const label[] = { d,u,t,NO1,h,i,   NUL }; ADD(spu.ch1.duty.high); }
 	{ static const char label[] = { e,n,v,NO1,c,t,r, NUL }; ADD(spu.ch1.env.counter); }
 	{ static const char label[] = { e,n,v,NO1,v,o,l, NUL }; ADD(spu.ch1.env.volume); }
 	{ static const char label[] = { l,e,n,NO1,c,t,r, NUL }; ADD(spu.ch1.lcounter.counter); }
@@ -386,6 +392,7 @@ SaverList::SaverList() {
 	{ static const char label[] = { c,NO1,m,a,s,t,r, NUL }; ADD(spu.ch1.master); }
 	{ static const char label[] = { d,u,t,NO2,c,t,r, NUL }; ADD(spu.ch2.duty.nextPosUpdate); }
 	{ static const char label[] = { d,u,t,NO2,p,o,s, NUL }; ADD(spu.ch2.duty.pos); }
+	{ static char const label[] = { d,u,t,NO2,h,i,   NUL }; ADD(spu.ch2.duty.high); }
 	{ static const char label[] = { e,n,v,NO2,c,t,r, NUL }; ADD(spu.ch2.env.counter); }
 	{ static const char label[] = { e,n,v,NO2,v,o,l, NUL }; ADD(spu.ch2.env.volume); }
 	{ static const char label[] = { l,e,n,NO2,c,t,r, NUL }; ADD(spu.ch2.lcounter.counter); }


### PR DESCRIPTION
This was a fun bug...

At present, the core randomly hard locks the system when loading save states on the 3DS (issue #103). This also happens on the Vita (issue #97).

After a great deal of debugging misery (working with the 3DS is a nightmare), it turns out that this problem actually affects all platforms. It seems that when the core was ported to RetroArch, two boolean state variables were omitted from the 'StateSaver' code: `spu.ch1.duty.high` and `spu.ch2.duty.high`. Since these values are never getting set when loading a state, we're left with uninitialised automatic variables - i.e. complete garbage.

It just so happens that *most* of the time, on *most* platforms, we get lucky and they end up as 0 - but not always, and not on the 3DS. Quite apart from the fact that this means save states have never worked 'properly' (the spu isn't restored correctly), these booleans are used to generate some important counter values - if they don't resolve as either 0 or 1, then these counters break and the core gets stuck in infinite loops. Hence the system lock ups on the 3DS. I was also able to reproduce this under Linux (eventually...).

This pull request fixes the issue! While I was editing the StateSaver, I also added two other missing network-related state variables - every parameter is now accounted for.

This should close issues #103 and #97 (I don't own a Vita and so cannot test the latter, but the bug and the fix were clear and obvious in the end).

Note that this will invalidate any existing save states made with the core, but since they were incomplete anyway I don't think this is much of a loss.