### PR TITLE
Add optional frame mixing

### DIFF
--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -60,6 +60,10 @@ static gambatte::GB gb2;
 
 bool use_official_bootloader = false;
 
+// Colours from previous frame
+static gambatte::video_pixel_t prev_colours[160 * NUM_GAMEBOYS * 144] = {0};
+static bool blur_motion = false;
+
 bool file_present_in_system(std::string fname)
 {
    const char *systemdirtmp = NULL;
@@ -365,6 +369,7 @@ Special 3"
       { "gambatte_dark_filter_level", "Dark Filter Level (percent); 0|5|10|15|20|25|30|35|40|45|50" },
       { "gambatte_gb_hwmode", "Emulated hardware (restart); Auto|GB|GBC|GBA" },
       { "gambatte_gb_bootloader", "Use official bootloader (restart); enabled|disabled" },
+      { "gambatte_mix_frames", "Mix frames; disabled|enabled" },
 #ifdef HAVE_NETWORK
       { "gambatte_gb_link_mode", "GameBoy Link Mode; Not Connected|Network Server|Network Client" },
       { "gambatte_gb_link_network_port", "Network Link Port; 56400|56401|56402|56403|56404|56405|56406|56407|56408|56409|56410|56411|56412|56413|56414|56415|56416|56417|56418|56419|56420" },
@@ -423,6 +428,8 @@ void retro_reset()
       memcpy(gb.rtcdata_ptr(), rtc, gb.rtcdata_size());
       delete[] rtc;
    }
+
+   memset(prev_colours, 0, sizeof(gambatte::video_pixel_t) * 160 * NUM_GAMEBOYS * 144);
 }
 
 static size_t serialize_size = 0;
@@ -640,6 +647,22 @@ static void check_variables(void)
    }
    else
       up_down_allowed = false;
+
+   bool prev_blur_motion = blur_motion;
+   blur_motion = false;
+   var.key   = "gambatte_mix_frames";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+     if (!strcmp(var.value, "enabled")) {
+         blur_motion = true;
+      }
+   }
+   // Must reset previous colours when turning 'mix frames'
+   // on, otherwise first rendered frame may contain garbage
+   if (!prev_blur_motion && blur_motion) {
+      memset(prev_colours, 0, sizeof(gambatte::video_pixel_t) * 160 * NUM_GAMEBOYS * 144);
+   }
 
 #ifdef HAVE_NETWORK
    gb_serialMode = SERIAL_NONE;
@@ -1029,6 +1052,46 @@ static void render_audio(const int16_t *samples, unsigned frames)
    blipper_push_samples(resampler_r, samples + 1, frames, 2);
 }
 
+static void mix_frames(void)
+{
+   // Simple frame blending: mixes current frame 50:50 with
+   // previous one
+   unsigned offset = 0;
+   unsigned colour_index = 0;
+   for (unsigned i = 0; i < 144; i++)
+   {
+      for (unsigned j = 0; j < 160 * NUM_GAMEBOYS; j++)
+      {
+         // Get colours from current frame + previous frame
+         unsigned buff_index = offset + j;
+         gambatte::video_pixel_t rgb = video_buf[buff_index];
+         gambatte::video_pixel_t rgb_prev = prev_colours[colour_index];
+         
+         // Store current colours for next frame
+         prev_colours[colour_index] = rgb;
+         colour_index++;
+         
+         // Mix colours for current frame
+         // Do this in one shot to minimise unnecessary variables...
+         // > Unpack current/previous frame colours and divide by 2
+         // > Mix and repack colours for current frame
+         // Note: This will darken colours, due to rounding errors
+         // (not much we can do about this without incurring a large
+         // performance penalty...)
+#ifdef VIDEO_RGB565
+         video_buf[buff_index] =   (((rgb >> 11 & 0x1F) >> 1) + ((rgb_prev >> 11 & 0x1F) >> 1)) << 11
+                                 | (((rgb >>  6 & 0x1F) >> 1) + ((rgb_prev >>  6 & 0x1F) >> 1)) << 6
+                                 | (((rgb       & 0x1F) >> 1) + ((rgb_prev       & 0x1F) >> 1));
+#else
+         video_buf[buff_index] =   (((rgb >> 16 & 0x1F) >> 1) + ((rgb_prev >> 16 & 0x1F) >> 1)) << 16
+                                 | (((rgb >>  8 & 0x1F) >> 1) + ((rgb_prev >>  8 & 0x1F) >> 1)) << 8
+                                 | (((rgb       & 0x1F) >> 1) + ((rgb_prev       & 0x1F) >> 1));
+#endif
+      }
+      offset += video_pitch;
+   }
+}
+
 void retro_run()
 {
    static uint64_t samples_count = 0;
@@ -1085,6 +1148,10 @@ void retro_run()
 #else
    render_audio(sound_buf.i16, samples);
 #endif
+
+   if (blur_motion) {
+      mix_frames();
+   }
 
 #ifdef VIDEO_RGB565
    video_cb(video_buf, 160*NUM_GAMEBOYS, 144, 512*NUM_GAMEBOYS);


### PR DESCRIPTION
A number of GB/GBC games create fake transparency effects (or generate 'extra' shades of grey) by drawing objects on alternate frames, and relying on the LCD ghosting properties of the original hardware to smooth things out. Notable examples are Wave Race, Ballistic and Chikyuu Kaihou Gun ZAS. These games are currently unplayable using the Gambatte core (without a shader) since they produce an epilepsy-inducing 30Hz strobe pattern (this kind of rapid frame switching is also reported to cause burn-in on 3DS screens).

This pull request adds a 'Mix frames' core option which enables very simple blending between the current and previous frames. This fixes all games that would otherwise 'flicker', and I guess it can also be used as a low-fi generic motion blur option (for people who like such things). I should probably note that turning 'Mix frames' on will darken colours a little, due to rounding errors (we have very limited precision here...) - but certainly for the games it is intended for, this is not really an issue.