### PR TITLE
Update GBC colour correction 

### DIFF
--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -114,6 +114,7 @@ public:
 
    void setColorCorrection(bool enable);
    void setColorCorrectionMode(unsigned colorCorrectionMode);
+   void setColorCorrectionBrightness(float colorCorrectionBrightness);
    void setDarkFilterLevel(unsigned darkFilterLevel);
    video_pixel_t gbcToRgb32(const unsigned bgr15);
 

--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -366,6 +366,7 @@ Special 3"
 }, // So many... place on seperate lines for readability...
       { "gambatte_gbc_color_correction", "Color correction; GBC only|always|disabled" },
       { "gambatte_gbc_color_correction_mode", "Color correction mode; accurate|fast" },
+      { "gambatte_gbc_frontlight_position", "Color correction - frontlight position; central|above screen|below screen" },
       { "gambatte_dark_filter_level", "Dark Filter Level (percent); 0|5|10|15|20|25|30|35|40|45|50" },
       { "gambatte_gb_hwmode", "Emulated hardware (restart); Auto|GB|GBC|GBA" },
       { "gambatte_gb_bootloader", "Use official bootloader (restart); enabled|disabled" },
@@ -625,6 +626,18 @@ static void check_variables(void)
       colorCorrectionMode = 1;
    }
    gb.setColorCorrectionMode(colorCorrectionMode);
+   
+   float colorCorrectionBrightness = 0.5f; /* central */
+   var.key   = "gambatte_gbc_frontlight_position";
+   var.value = NULL;
+   if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
+   {
+      if (!strcmp(var.value, "above screen"))
+         colorCorrectionBrightness = 1.2f;
+      else if (!strcmp(var.value, "below screen"))
+         colorCorrectionBrightness = 0.0f;
+   }
+   gb.setColorCorrectionBrightness(colorCorrectionBrightness);
    
    unsigned darkFilterLevel = 0;
    var.key   = "gambatte_dark_filter_level";

--- a/libgambatte/src/gambatte-memory.h
+++ b/libgambatte/src/gambatte-memory.h
@@ -49,6 +49,7 @@ public:
    unsigned rtcdata_size() { return cart_.rtcdata_size(); }
    void display_setColorCorrection(bool enable) { lcd_.setColorCorrection(enable); }
    void display_setColorCorrectionMode(unsigned colorCorrectionMode) { lcd_.setColorCorrectionMode(colorCorrectionMode); }
+   void display_setColorCorrectionBrightness(float colorCorrectionBrightness) { lcd_.setColorCorrectionBrightness(colorCorrectionBrightness); }
    void display_setDarkFilterLevel(unsigned darkFilterLevel) { lcd_.setDarkFilterLevel(darkFilterLevel); }
    video_pixel_t display_gbcToRgb32(const unsigned bgr15) { return lcd_.gbcToRgb32(bgr15); }
    void clearCheats() { cart_.clearCheats(); }

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -158,6 +158,10 @@ void GB::setColorCorrectionMode(unsigned colorCorrectionMode) {
    p_->cpu.mem_.display_setColorCorrectionMode(colorCorrectionMode);
 }
 
+void GB::setColorCorrectionBrightness(float colorCorrectionBrightness) {
+   p_->cpu.mem_.display_setColorCorrectionBrightness(colorCorrectionBrightness);
+}
+
 void GB::setDarkFilterLevel(unsigned darkFilterLevel) {
    p_->cpu.mem_.display_setDarkFilterLevel(darkFilterLevel);
 }

--- a/libgambatte/src/video.h
+++ b/libgambatte/src/video.h
@@ -155,6 +155,7 @@ class LCD
 
       void setColorCorrection(bool colorCorrection);
       void setColorCorrectionMode(unsigned colorCorrectionMode);
+      void setColorCorrectionBrightness(float colorCorrectionBrightness);
       void setDarkFilterLevel(unsigned darkFilterLevel);
       video_pixel_t gbcToRgb32(const unsigned bgr15);
    private:
@@ -228,6 +229,7 @@ class LCD
 
       bool colorCorrection;
       unsigned colorCorrectionMode;
+      float colorCorrectionBrightness;
       unsigned darkFilterLevel;
       void doCgbColorChange(unsigned char *const pdata,
             video_pixel_t *const palette, unsigned index, const unsigned data);


### PR DESCRIPTION
This PR updates Gambatte's internal 'accurate' GBC colour correction with the results from Pokefan531's latest research (https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540/174).

It also adds a new core option `Color correction - frontlight position`, which simulates GBC screen brightness when illuminated from different angles (corresponding to the 3 gamma correction presets detailed in Pokefan531's post).

Here are some screenshots demonstrating the new colour correction with each of the 'frontlight position` settings:

`above screen` ---> `central` (default) ---> `below screen`

<img src="https://user-images.githubusercontent.com/38211560/55175143-a81d6400-5176-11e9-8503-e32e35bc7357.png" width="160" height="144"><img src="https://user-images.githubusercontent.com/38211560/55175184-b66b8000-5176-11e9-91f7-d20973f8fa0d.png" width="160" height="144"><img src="https://user-images.githubusercontent.com/38211560/55175196-bb303400-5176-11e9-9480-2d49cf6295cf.png" width="160" height="144">

<img src="https://user-images.githubusercontent.com/38211560/55175257-de5ae380-5176-11e9-9567-7ace028b69e1.png" width="160" height="144"><img src="https://user-images.githubusercontent.com/38211560/55175265-e1ee6a80-5176-11e9-879d-f93ddcbc7429.png" width="160" height="144"><img src="https://user-images.githubusercontent.com/38211560/55175268-e4e95b00-5176-11e9-88d8-5e4baec80f32.png" width="160" height="144">

<img src="https://user-images.githubusercontent.com/38211560/55175348-05b1b080-5177-11e9-86df-d98b9ae5a48b.png" width="160" height="144"><img src="https://user-images.githubusercontent.com/38211560/55175354-09453780-5177-11e9-8f71-117e84bb43d7.png" width="160" height="144"><img src="https://user-images.githubusercontent.com/38211560/55175361-0ba79180-5177-11e9-9f88-3968754bf20d.png" width="160" height="144">

<img src="https://user-images.githubusercontent.com/38211560/55175404-237f1580-5177-11e9-81c8-2c16edac9a1f.png" width="160" height="144"><img src="https://user-images.githubusercontent.com/38211560/55175411-27129c80-5177-11e9-8caa-5dbe12103446.png" width="160" height="144"><img src="https://user-images.githubusercontent.com/38211560/55175416-2a0d8d00-5177-11e9-89bf-81c877ee0edd.png" width="160" height="144">
