### PR TITLE
Add static GBC RAM banks memory descriptor

### DIFF
--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -984,6 +984,7 @@ bool retro_load_game(const struct retro_game_info *info)
       { mainram, gb.rambank0_ptr(),  0, 0xC000,               0, 0, 0x1000,                        NULL },
       { mainram, gb.bankedram_ptr(), 0, 0xD000,               0, 0, 0x1000,                        NULL },
       { mainram, gb.zeropage_ptr(),  0, 0xFF80,               0, 0, 0x0080,                        NULL },
+      { mainram, gb.rambank1_ptr(),  0, 0x10000,              0, 0, gb.isCgb() ? 0x7000 : 0,       NULL },
       {       0, gb.savedata_ptr(),  0, 0xA000, (size_t)~0x1FFF, 0, sramlen,                       NULL },
       {       0, gb.vram_ptr(),      0, 0x8000,               0, 0, 0x2000,                        NULL },
       {       0, gb.oamram_ptr(),    0, 0xFE00,               0, 0, 0x00A0,                        NULL },


### PR DESCRIPTION
This matches a change to the reference map as applied here: https://github.com/RetroAchievements/RAIntegration/commit/6d710b17c33fc1e729eeaf2fbd1bc4c7d011c429.

The region is appended to the tail end to maintain backwards-compatibility.