### PR TITLE
Do not drop memory descriptor when SRAM is absent

### DIFF
--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -995,7 +995,7 @@ bool retro_load_game(const struct retro_game_info *info)
    struct retro_memory_map mmaps =
    {
       descs,
-      sizeof(descs) / sizeof(descs[0]) - (sramlen == 0)
+      sizeof(descs) / sizeof(descs[0])
    };
    
    environ_cb(RETRO_ENVIRONMENT_SET_MEMORY_MAPS, &mmaps);


### PR DESCRIPTION
If SRAM is missing, a length of 0 will be returned, which should not cause a problem when mapped.