### PR TITLE
Always count GBC RAM in the system RAM memory size

### DIFF
--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -1049,10 +1049,13 @@ size_t retro_get_memory_size(unsigned id)
           * libgambatte/src/memory/cartridge.cpp not changing
           * the call to memptrs.reset, but this is 
           * probably mostly safe.
+	  *
+	  * The size is fetched before the system can be set to
+	  * GBC, so we overestimate the size when in GB mode.
           *
           * GBC will probably not get a
           * hardware upgrade anytime soon. */
-         return (gb.isCgb() ? 8 : 2) * 0x1000ul;
+         return 8 * 0x1000ul;
    }
 
    return 0;


### PR DESCRIPTION
This is necessary to enable access to the GBC extended RAM.

The conditional is always false at the point where this function is called,
and memory descriptors should take the system into account correctly.