### PR TITLE
Update GBC memory map

### DIFF
--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -134,6 +134,7 @@ public:
    void *vram_ptr() const;
    void *rambank0_ptr() const;
    void *rambank1_ptr() const;
+   void *rambank2_ptr() const;
    void *bankedram_ptr() const;
    void *rombank0_ptr() const;
    void *rombank1_ptr() const;

--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -982,14 +982,14 @@ bool retro_load_game(const struct retro_game_info *info)
    struct retro_memory_descriptor descs[] =
    {
       { mainram, gb.rambank0_ptr(),  0, 0xC000,               0, 0, 0x1000,                        NULL },
-      { mainram, gb.bankedram_ptr(), 0, 0xD000,               0, 0, 0x1000,                        NULL },
+      { mainram, gb.rambank1_ptr(),  0, 0xD000,               0, 0, 0x1000,                        NULL },
       { mainram, gb.zeropage_ptr(),  0, 0xFF80,               0, 0, 0x0080,                        NULL },
-      { mainram, gb.rambank1_ptr(),  0, 0x10000,              0, 0, gb.isCgb() ? 0x7000 : 0,       NULL },
-      {       0, gb.savedata_ptr(),  0, 0xA000, (size_t)~0x1FFF, 0, sramlen,                       NULL },
       {       0, gb.vram_ptr(),      0, 0x8000,               0, 0, 0x2000,                        NULL },
       {       0, gb.oamram_ptr(),    0, 0xFE00,               0, 0, 0x00A0,                        NULL },
       {     rom, gb.rombank0_ptr(),  0, 0x0000,               0, 0, 0x4000,                        NULL },
       {     rom, gb.rombank1_ptr(),  0, 0x4000,               0, 0, 0x4000,                        NULL },
+      {       0, gb.savedata_ptr(),  0, 0xA000, (size_t)~0x1FFF, 0, sramlen,                       NULL },
+      { mainram, gb.rambank2_ptr(),  0, 0x10000,              0, 0, gb.isCgb() ? 0x6000 : 0,       NULL },
    };
    
    struct retro_memory_map mmaps =

--- a/libgambatte/src/cpu.h
+++ b/libgambatte/src/cpu.h
@@ -50,6 +50,7 @@ public:
    void *vram_ptr() const { return mem_.vram_ptr(); }
    void *rambank0_ptr() const { return mem_.rambank0_ptr(); }
    void *rambank1_ptr() const { return mem_.rambank1_ptr(); }
+   void *rambank2_ptr() const { return mem_.rambank2_ptr(); }
    void *bankedram_ptr() const { return mem_.bankedram_ptr(); }
    void *rombank0_ptr() const { return mem_.rombank0_ptr(); }
    void *rombank1_ptr() const { return mem_.rombank1_ptr(); }

--- a/libgambatte/src/gambatte-memory.h
+++ b/libgambatte/src/gambatte-memory.h
@@ -56,6 +56,7 @@ public:
    void *vram_ptr() const { return cart_.vramdata(); }
    void *rambank0_ptr() const { return cart_.wramdata(0); }
    void *rambank1_ptr() const { return cart_.wramdata(0) + 0x1000; }
+   void *rambank2_ptr() const { return cart_.wramdata(0) + 0x2000; }
    void *bankedram_ptr() const { return cart_.wramdata(1); }
    void *rombank0_ptr() const { return cart_.romdata(0); }
    void *rombank1_ptr() const { return cart_.romdata(0) + 0x4000; }

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -196,6 +196,10 @@ void *GB::rambank1_ptr() const {
  return p_->cpu.rambank1_ptr();
 }
 
+void *GB::rambank2_ptr() const {
+ return p_->cpu.rambank2_ptr();
+}
+
 void *GB::bankedram_ptr() const {
  return p_->cpu.bankedram_ptr();
 }


### PR DESCRIPTION
Matches a change to the reference map (https://github.com/RetroAchievements/RAIntegration/pull/366).

Because RA receives memory layout once and does not change it on the fly, the reference map was not compatible. Recent changes appending GBC banks were revised to only map banks 2-7, while the default bank (1) is set to where the "current bank" used to be (no difference in practice, except for removing a duplicate mapping). Left in helper functions to make modifications easier, but they can also be removed or parameterized for cleaner design.