### PR TITLE
Fix cheats for libretro

### DIFF
--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -23,6 +23,7 @@
 #include <cstdlib>
 #include <string>
 #include <cstring>
+#include <algorithm>
 
 #ifdef _3DS
 extern "C" void* linearMemAlign(size_t size, size_t alignment);
@@ -468,11 +469,15 @@ void retro_cheat_reset()
 
 void retro_cheat_set(unsigned index, bool enabled, const char *code)
 {
-   std::string s = code;
-   if (s.find("-") != std::string::npos)
-      gb.setGameGenie(code);
-   else
-      gb.setGameShark(code);
+   std::string code_str(code);
+
+   replace(code_str.begin(), code_str.end(), '+', ';');
+
+   if (code_str.find("-") != std::string::npos) {
+      gb.setGameGenie(code_str);
+   } else {
+      gb.setGameShark(code_str);
+   }
 }
 
    

--- a/libgambatte/src/gambatte-memory.cpp
+++ b/libgambatte/src/gambatte-memory.cpp
@@ -1170,7 +1170,7 @@ int Memory::loadROM(const void *romdata, unsigned int romsize, unsigned int forc
       return fail;
    psg_.init(cart_.isCgb());
    lcd_.reset(ioamhram_, cart_.vramdata(), cart_.isCgb());
-   interrupter_.setGameShark(std::string());
+   interrupter_.clearCheats();
    return 0;
 }
 

--- a/libgambatte/src/gambatte-memory.h
+++ b/libgambatte/src/gambatte-memory.h
@@ -52,7 +52,7 @@ public:
    void display_setColorCorrectionBrightness(float colorCorrectionBrightness) { lcd_.setColorCorrectionBrightness(colorCorrectionBrightness); }
    void display_setDarkFilterLevel(unsigned darkFilterLevel) { lcd_.setDarkFilterLevel(darkFilterLevel); }
    video_pixel_t display_gbcToRgb32(const unsigned bgr15) { return lcd_.gbcToRgb32(bgr15); }
-   void clearCheats() { cart_.clearCheats(); }
+   void clearCheats() { cart_.clearCheats(); interrupter_.clearCheats(); }
    void *vram_ptr() const { return cart_.vramdata(); }
    void *rambank0_ptr() const { return cart_.wramdata(0); }
    void *rambank1_ptr() const { return cart_.wramdata(0) + 0x1000; }

--- a/libgambatte/src/interrupter.cpp
+++ b/libgambatte/src/interrupter.cpp
@@ -49,7 +49,6 @@ static int asHex(char c) {
 
 void Interrupter::setGameShark(std::string const &codes) {
 	std::string code;
-	gsCodes_.clear();
 
 	for (std::size_t pos = 0; pos < codes.length(); pos += code.length() + 1) {
 		code = codes.substr(pos, codes.find(';', pos) - pos);
@@ -64,6 +63,10 @@ void Interrupter::setGameShark(std::string const &codes) {
 			gsCodes_.push_back(gs);
 		}
 	}
+}
+
+void Interrupter::clearCheats() {
+	gsCodes_.clear();
 }
 
 void Interrupter::applyVblankCheats(unsigned long const cc, Memory &memory) {

--- a/libgambatte/src/interrupter.h
+++ b/libgambatte/src/interrupter.h
@@ -37,6 +37,7 @@ public:
 	Interrupter(unsigned short &sp, unsigned short &pc);
 	unsigned long interrupt(unsigned address, unsigned long cycleCounter, Memory &memory);
 	void setGameShark(std::string const &codes);
+	void clearCheats();
 
 private:
 	unsigned short &sp_;

--- a/libgambatte/src/mem/cartridge.cpp
+++ b/libgambatte/src/mem/cartridge.cpp
@@ -678,19 +678,22 @@ namespace gambatte
       if (loaded())
 #endif
       {
-         for (std::vector<AddrData>::reverse_iterator it = ggUndoList_.rbegin(), end = ggUndoList_.rend(); it != end; ++it)
-         {
-            if (memptrs_.romdata() + it->addr < memptrs_.romdataend())
-               memptrs_.romdata()[it->addr] = it->data;
-         }
-
-         ggUndoList_.clear();
-
          std::string code;
          for (std::size_t pos = 0; pos < codes.length()
                && (code = codes.substr(pos, codes.find(';', pos) - pos), true); pos += code.length() + 1)
             applyGameGenie(code);
       }
+   }
+
+   void Cartridge::clearCheats()
+   {
+       for (std::vector<AddrData>::reverse_iterator it = ggUndoList_.rbegin(), end = ggUndoList_.rend(); it != end; ++it)
+          {
+             if (memptrs_.romdata() + it->addr < memptrs_.romdataend())
+                memptrs_.romdata()[it->addr] = it->data;
+          }
+
+       ggUndoList_.clear();
    }
 
 }

--- a/libgambatte/src/mem/cartridge_libretro.cpp
+++ b/libgambatte/src/mem/cartridge_libretro.cpp
@@ -81,9 +81,4 @@ namespace gambatte
       return 0;
    }
 
-   void Cartridge::clearCheats()
-   {
-      ggUndoList_.clear();
-   }
-
 }


### PR DESCRIPTION
Fixes #81 

The cheats were not integrated properly, as a result, only the last
cheat was applied. This is because gamebatte expects all cheats to be
set in one go and separated by a semi-colon. But the libretro api wants
to apply cheats one at a time. Therefore every time a cheat is applied
it disables the previous one.

Also clearCheats was not properly implemented at all, it did not take
into account gameshark codes and it was simply not working for gamegenie,
therefore it was impossible to disable a cheat without reloading the core.