### PR TITLE
Add optional LCD ghosting effect

### DIFF
--- a/libgambatte/libretro/libretro_core_options.h
+++ b/libgambatte/libretro/libretro_core_options.h
@@ -291,12 +291,14 @@ struct retro_core_option_definition option_defs_us[] = {
    },
    {
       "gambatte_mix_frames",
-      "Mix Frames",
-      "Enable simulation of LCD ghosting effects by blending the current and previous frames. 'Accurate' blends pixel values with high precision. 'Fast' uses an approximation, which causes slight color darkening/shifting but allows full speed operation on very low-end hardware. Frame mixing is required when playing games that rely on LCD ghosting for transparency effects (Wave Race, Ballistic, Chikyuu Kaihou Gun ZAS...).",
+      "Interframe Blending",
+      "Simulates LCD ghosting effects. 'Simple' performs a 50:50 mix of the current and previous frames. 'LCD Ghosting' mimics natural LCD response times by combining multiple buffered frames. 'Simple' blending is required when playing games that rely on LCD ghosting for transparency effects (Wave Race, Ballistic, Chikyuu Kaihou Gun ZAS...).",
       {
-         { "disabled", NULL },
-         { "accurate", "Accurate" },
-         { "fast",     "Fast" },
+         { "disabled",          NULL },
+         { "mix",               "Simple (Accurate)" },
+         { "mix_fast",          "Simple (Fast)" },
+         { "lcd_ghosting",      "LCD Ghosting (Accurate)" },
+         { "lcd_ghosting_fast", "LCD Ghosting (Fast)" },
          { NULL, NULL },
       },
       "disabled"


### PR DESCRIPTION
This PR backports the LCD ghosting effects that were recently added to mGBA: https://github.com/libretro/mgba/pull/175, https://github.com/libretro/mgba/pull/176

It replaces the existing `Mix Frames` core option with `Interframe Blending`. The old `Accurate` and `Fast` frame mixing settings have been renamed to `Simple (Accurate)` and `Simple (Fast)` - these perform the same 50:50 mix of the current and previous frames as before, required to achieve correct rendering of games that rely on LCD ghosting for transparency effects.

In addition to these settings, there are now `LCD Ghosting (Accurate)` and `LCD Ghosting (Fast)` options. The former recreates the LCD response effect of RetroArch's [Gameboy Shader](https://github.com/libretro/glsl-shaders/tree/master/handheld/shaders/gameboy). The latter is similar, but uses a single accumulation buffer - which is more efficient, but lacks the subtlety of the shader implementation.

Here are some stats showing the typical increase in performance overheads when using the various methods:


- `Simple (Accurate)`: 30%
- `Simple (Fast)`: 13%
- `LCD Ghosting (Accurate)`: 48%
- `LCD Ghosting (Fast)`: 28%
