### PR TITLE
Authentic palettes derived from original hardware screens (pt. 2)

### DIFF
--- a/libgambatte/libretro/gbcpalettes.h
+++ b/libgambatte/libretro/gbcpalettes.h
@@ -31,21 +31,21 @@ namespace {
 // Game Boy Palettes
 //
 static const unsigned short gbdmg[] = { // Original Game Boy
-	PACK15_4(0x7F860F, 0x577C44, 0x365D48, 0x2A453B),
-	PACK15_4(0x7F860F, 0x577C44, 0x365D48, 0x2A453B),
-	PACK15_4(0x7F860F, 0x577C44, 0x365D48, 0x2A453B)
+	PACK15_4(0x819A32, 0x61873E, 0x365D48, 0x2A453C),
+	PACK15_4(0x819A32, 0x61873E, 0x365D48, 0x2A453C),
+	PACK15_4(0x819A32, 0x61873E, 0x365D48, 0x2A453C)
 };
 
 static const unsigned short gbpoc[] = { // Game Boy Pocket
-	PACK15_4(0xC6CFA5, 0x8C966B, 0x4A5139, 0x181C18),
-	PACK15_4(0xC6CFA5, 0x8C966B, 0x4A5139, 0x181C18),
-	PACK15_4(0xC6CFA5, 0x8C966B, 0x4A5139, 0x181C18)
+	PACK15_4(0x949B8B, 0x7C8870, 0x525F4B, 0x394038),
+	PACK15_4(0x949B8B, 0x7C8870, 0x525F4B, 0x394038),
+	PACK15_4(0x949B8B, 0x7C8870, 0x525F4B, 0x394038)
 };
 
 static const unsigned short gblit[] = { // Game Boy Light
-	PACK15_4(0x00B581, 0x009A71, 0x00694A, 0x004F3B),
-	PACK15_4(0x00B581, 0x009A71, 0x00694A, 0x004F3B),
-	PACK15_4(0x00B581, 0x009A71, 0x00694A, 0x004F3B)
+	PACK15_4(0x01CBDF, 0x01B6D5, 0x269BAD, 0x00778D),
+	PACK15_4(0x01CBDF, 0x01B6D5, 0x269BAD, 0x00778D),
+	PACK15_4(0x01CBDF, 0x01B6D5, 0x269BAD, 0x00778D)
 };
 
 //
@@ -1039,9 +1039,9 @@ struct GbcPaletteEntry { const char *title; const unsigned short *p; };
 
 // Note: These entries must be in alphabetical order
 static const GbcPaletteEntry gbcDirPalettes[] = {
-	{ "GB - DMG", gbdmg },    // Pea green
-	{ "GB - Light", gblit },  // Aquamarine
-	{ "GB - Pocket", gbpoc }, // Pristine greyscale
+	{ "GB - DMG", gbdmg },    // Original Game Boy
+	{ "GB - Light", gblit },  // Original Game Boy Light
+	{ "GB - Pocket", gbpoc }, // Original Game Boy Pocket
 	{ "GBC - Blue", p518 },       // Left
 	{ "GBC - Brown", p012 },      // Up
 	{ "GBC - Dark Blue", p50D },  // A + Left


### PR DESCRIPTION
There, only relevant commits and nothing else.

This should be as close to hardware as possible.

![image](https://user-images.githubusercontent.com/50436544/85786585-b1ef9780-b72a-11ea-955e-705277a428c4.png)

![image](https://user-images.githubusercontent.com/50436544/85786609-b6b44b80-b72a-11ea-8f48-c55b95114799.png)

![image](https://user-images.githubusercontent.com/50436544/85786633-bae06900-b72a-11ea-8265-e505c8543ad4.png)

![image](https://user-images.githubusercontent.com/50436544/85786655-bfa51d00-b72a-11ea-91f3-f7dcac3c57a5.png)

Work based on these screen captures

![image](https://user-images.githubusercontent.com/50436544/85786724-d0ee2980-b72a-11ea-8a36-25378b556656.png)

![image](https://user-images.githubusercontent.com/50436544/85786750-d8153780-b72a-11ea-91ba-4c0845088896.png)

![image](https://user-images.githubusercontent.com/50436544/85786775-de0b1880-b72a-11ea-90d6-450221fe4e71.png)
