### PR TITLE
Game Boy palette corrected

### DIFF
--- a/libgambatte/libretro/gbcpalettes.h
+++ b/libgambatte/libretro/gbcpalettes.h
@@ -31,9 +31,9 @@ namespace {
 // Game Boy Palettes
 //
 static const unsigned short gbdmg[] = { // Original Game Boy
-	PACK15_4(0x819A32, 0x61873E, 0x365D48, 0x2A453C),
-	PACK15_4(0x819A32, 0x61873E, 0x365D48, 0x2A453C),
-	PACK15_4(0x819A32, 0x61873E, 0x365D48, 0x2A453C)
+	PACK15_4(0x578200, 0x317400, 0x005121, 0x00420C),
+	PACK15_4(0x578200, 0x317400, 0x005121, 0x00420C),
+	PACK15_4(0x578200, 0x317400, 0x005121, 0x00420C)
 };
 
 static const unsigned short gbpoc[] = { // Game Boy Pocket


### PR DESCRIPTION
A terrible mistake made the previous committed Game Boy Palette look entirely wrong compared from how it looked in my demo shots.

This should take care of it once and for all (tested all three palettes again and Original Game Boy looks correct now)

![image](https://user-images.githubusercontent.com/50436544/85814705-da958280-b766-11ea-952a-0b14733e489e.png)
