### PR TITLE
Update GBC colour correction parameters

### DIFF
--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -1099,7 +1099,7 @@ static void check_variables(void)
    if (environ_cb(RETRO_ENVIRONMENT_GET_VARIABLE, &var) && var.value)
    {
       if (!strcmp(var.value, "above screen"))
-         colorCorrectionBrightness = 1.2f;
+         colorCorrectionBrightness = 1.0f;
       else if (!strcmp(var.value, "below screen"))
          colorCorrectionBrightness = 0.0f;
    }

--- a/libgambatte/src/video_libretro.cpp
+++ b/libgambatte/src/video_libretro.cpp
@@ -23,15 +23,16 @@
 #include <cmath>
 
 /* GBC colour correction factors */
-#define GBC_CC_R  0.87
-#define GBC_CC_G  0.66
-#define GBC_CC_B  0.79
-#define GBC_CC_RG 0.115
-#define GBC_CC_RB 0.14
-#define GBC_CC_GR 0.18
-#define GBC_CC_GB 0.07
-#define GBC_CC_BR -0.05
-#define GBC_CC_BG 0.225
+#define GBC_CC_LUM 0.94f
+#define GBC_CC_R   0.82f
+#define GBC_CC_G   0.665f
+#define GBC_CC_B   0.73f
+#define GBC_CC_RG  0.125f
+#define GBC_CC_RB  0.195f
+#define GBC_CC_GR  0.24f
+#define GBC_CC_GB  0.075f
+#define GBC_CC_BR  -0.06f
+#define GBC_CC_BG  0.21f
 
 namespace gambatte
 {
@@ -210,7 +211,7 @@ namespace gambatte
          else
          {
             // Use Pokefan531's "gold standard" GBC colour correction
-            // (https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540/174)
+            // (https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540/190)
             // NB: The results produced by this implementation are ever so slightly
             // different from the output of the gbc-colour shader. This is due to the
             // fact that we have to tolerate rounding errors here that are simply not
@@ -228,9 +229,9 @@ namespace gambatte
             float gFloat = std::pow(static_cast<float>(g) * rgbMaxInv, adjustedGamma);
             float bFloat = std::pow(static_cast<float>(b) * rgbMaxInv, adjustedGamma);
             // Perform colour mangling
-            float rCorrect = (GBC_CC_R  * rFloat) + (GBC_CC_GR * gFloat) + (GBC_CC_BR * bFloat);
-            float gCorrect = (GBC_CC_RG * rFloat) + (GBC_CC_G  * gFloat) + (GBC_CC_BG * bFloat);
-            float bCorrect = (GBC_CC_RB * rFloat) + (GBC_CC_GB * gFloat) + (GBC_CC_B  * bFloat);
+            float rCorrect = GBC_CC_LUM * ((GBC_CC_R  * rFloat) + (GBC_CC_GR * gFloat) + (GBC_CC_BR * bFloat));
+            float gCorrect = GBC_CC_LUM * ((GBC_CC_RG * rFloat) + (GBC_CC_G  * gFloat) + (GBC_CC_BG * bFloat));
+            float bCorrect = GBC_CC_LUM * ((GBC_CC_RB * rFloat) + (GBC_CC_GB * gFloat) + (GBC_CC_B  * bFloat));
             // Range check...
             rCorrect = rCorrect > 0.0f ? rCorrect : 0.0f;
             gCorrect = gCorrect > 0.0f ? gCorrect : 0.0f;


### PR DESCRIPTION
This PR updates the GBC colour correction parameters with the results of Pokefan531's latest research: https://forums.libretro.com/t/real-gba-and-ds-phat-colors/1540/190

The difference is subtle, but noticeable - here are some before/after shots (with `Frontlight Postion` set to the default value of `Central`):

| Before   | After  |
|:-------------:|:------:|
| ![Legend of Zelda, The - Oracle of Seasons (Europe) (En,Fr,De,Es,It) (GBC)-200811-161356](https://user-images.githubusercontent.com/38211560/89920526-69b20900-dbf4-11ea-8028-4d6839d73e01.png) |  ![Legend of Zelda, The - Oracle of Seasons (Europe) (En,Fr,De,Es,It) (GBC)-200811-161541](https://user-images.githubusercontent.com/38211560/89920535-6b7bcc80-dbf4-11ea-86e4-5b97298846d7.png) |
| ![Pokemon Pinball (Europe) (En,Fr,De,Es,It) (Rumble Version) (SGB Enhanced) (GBC)-200811-161344](https://user-images.githubusercontent.com/38211560/89920590-7d5d6f80-dbf4-11ea-971e-761e5bc252b2.png) |   ![Pokemon Pinball (Europe) (En,Fr,De,Es,It) (Rumble Version) (SGB Enhanced) (GBC)-200811-161528](https://user-images.githubusercontent.com/38211560/89920595-7f273300-dbf4-11ea-98c0-b8487fa81f03.png)   |
| ![Shantae (USA) (GBC)-200811-161316](https://user-images.githubusercontent.com/38211560/89920643-8d754f00-dbf4-11ea-9561-f6351c3f33c4.png) | ![Shantae (USA) (GBC)-200811-161504](https://user-images.githubusercontent.com/38211560/89920646-8f3f1280-dbf4-11ea-9ca5-fd9327a37537.png) |
| ![Wario Land II (USA, Europe) (SGB Enhanced) (GBC)-200811-161330](https://user-images.githubusercontent.com/38211560/89920687-982fe400-dbf4-11ea-99df-c89a383c79ce.png) | ![Wario Land II (USA, Europe) (SGB Enhanced) (GBC)-200811-161515](https://user-images.githubusercontent.com/38211560/89920714-a41ba600-dbf4-11ea-99e0-c445db559ea9.png) |




