### PR TITLE
Fix 'GB - Pocket' internal palette

### DIFF
--- a/libgambatte/libretro/gbcpalettes.h
+++ b/libgambatte/libretro/gbcpalettes.h
@@ -37,9 +37,9 @@ static const unsigned short gbdmg[] = { // Original Game Boy
 };
 
 static const unsigned short gbpoc[] = { // Game Boy Pocket
-	PACK15_4(0x949B8B, 0x7C8870, 0x525F4B, 0x394038),
-	PACK15_4(0x949B8B, 0x7C8870, 0x525F4B, 0x394038),
-	PACK15_4(0x949B8B, 0x7C8870, 0x525F4B, 0x394038)
+	PACK15_4(0xA7B19A, 0x86927C, 0x535f49, 0x2A3325),
+	PACK15_4(0xA7B19A, 0x86927C, 0x535f49, 0x2A3325),
+	PACK15_4(0xA7B19A, 0x86927C, 0x535f49, 0x2A3325)
 };
 
 static const unsigned short gblit[] = { // Game Boy Light


### PR DESCRIPTION
PRs #152 and #153 recently made extensive changes to the internal `GB` palettes used to mimic original Game Boy hardware. While I have no objection to the updated `GB - DMG` and `GB - Light` palettes, the new `GB - Pocket` colours are not good...

For reference, here is the existing `GB - Pocket` palette compared with the 'original hardware' image from which it is purportedly derived:

| Hardware | Existing 'GB - Pocket` Palette |
|:--:|:--:|
|  ![gb_pocket_hardware](https://user-images.githubusercontent.com/38211560/90507850-7da6bf00-e14e-11ea-9ab2-0ed9b5f8db4c.jpg)  |  ![Donkey Kong (World) (Rev A) (SGB Enhanced)-200817-132550](https://user-images.githubusercontent.com/38211560/90507857-813a4600-e14e-11ea-85b9-4ca19ba10782.png)  |

The background and darkest values are of the wrong hue, and the artificially reduced contrast make the palette uncomfortable for real-world gaming (particularly for anyone with vision issues...) 

This PR takes the same 'original hardware' reference image, and determines the colours correctly, taking into account screen glare, uneven lighting and the colour mangling effects of the underlying LCD substrate. Brightness levels have then been adjusted to match those of a uniformly well-lit screen (at least, to match what my real GB Pocket looks like under fluorescent lighting - with good lighting, the darker shades in real life appear somewhat 'richer' than in the reference image...)  The 'corrected' palette looks like this:

| Hardware | Corrected 'GB - Pocket` Palette |
|:--:|:--:|
|  ![gb_pocket_hardware](https://user-images.githubusercontent.com/38211560/90508286-5997ad80-e14f-11ea-8064-fc5a5af7fdb7.jpg)  | ![Donkey Kong (World) (Rev A) (SGB Enhanced)-200818-122055](https://user-images.githubusercontent.com/38211560/90508306-661c0600-e14f-11ea-85ce-9505be2a56dd.png)   |
