### PR TITLE
Interframe Blending: Improve accuracy of 'Simple (Fast)' method, remove 'Simple (Accurate)' method

### DIFF
--- a/libgambatte/libretro/libretro_core_options.h
+++ b/libgambatte/libretro/libretro_core_options.h
@@ -295,8 +295,7 @@ struct retro_core_option_definition option_defs_us[] = {
       "Simulates LCD ghosting effects. 'Simple' performs a 50:50 mix of the current and previous frames. 'LCD Ghosting' mimics natural LCD response times by combining multiple buffered frames. 'Simple' blending is required when playing games that rely on LCD ghosting for transparency effects (Wave Race, Ballistic, Chikyuu Kaihou Gun ZAS...).",
       {
          { "disabled",          NULL },
-         { "mix",               "Simple (Accurate)" },
-         { "mix_fast",          "Simple (Fast)" },
+         { "mix",               "Simple" },
          { "lcd_ghosting",      "LCD Ghosting (Accurate)" },
          { "lcd_ghosting_fast", "LCD Ghosting (Fast)" },
          { NULL, NULL },


### PR DESCRIPTION
This PR improves the accuracy of the `Simple (Fast)` interframe blending option such that it produces the same results as the `Simple (Accurate)` method (while remaining > 33% faster). The `Simple (Accurate)` option has therefore been removed, and `Simple (Fast)` is now just named `Simple`.