### PR TITLE
Add rumble support

### DIFF
--- a/libgambatte/libretro/libretro_core_options.h
+++ b/libgambatte/libretro/libretro_core_options.h
@@ -302,6 +302,26 @@ struct retro_core_option_definition option_defs_us[] = {
       },
       "disabled"
    },
+   {
+      "gambatte_rumble_level",
+      "Gamepad Rumble Strength",
+      "Enables haptic feedback effects for supported games (Pokemon Pinball, Perfect Dark...).",
+      {
+         { "0",   NULL },
+         { "1",   NULL },
+         { "2",   NULL },
+         { "3",   NULL },
+         { "4",   NULL },
+         { "5",   NULL },
+         { "6",   NULL },
+         { "7",   NULL },
+         { "8",   NULL },
+         { "9",   NULL },
+         { "10",  NULL },
+         { NULL, NULL },
+      },
+      "10"
+   },
 #ifdef HAVE_NETWORK
    {
       "gambatte_show_gb_link_settings",


### PR DESCRIPTION
This PR adds rumble support for all Gameboy Color games released on rumble carts. A new `Gamepad Rumble Strength` core option allows the magnitude of the haptic feedback to be adjusted (setting this to zero disables rumble effects entirely).

There are two games with 'unofficial' rumble support - rumble can be enabled for these by editing the ROM file with a hex editor, as described in the following links:

- Disney's Tarzan: https://tcrf.net/Disney%27s_Tarzan_(Game_Boy_Color)
- Legend of the River King 2: https://tcrf.net/Legend_of_the_River_King_2

This PR closes #46, https://github.com/libretro/libretro-meta/issues/43