### PR TITLE
fix inverted src/dest arguments to memmove which broke GameLink clien…

### DIFF
--- a/libgambatte/libretro/net_serial.cpp
+++ b/libgambatte/libretro/net_serial.cpp
@@ -184,7 +184,7 @@ bool NetSerial::startClientSocket()
 			return false;
 		}
 
-		memmove((char*)server_hostname->h_addr, (char*)&server_addr.sin_addr.s_addr, server_hostname->h_length);
+		memmove((char*)&server_addr.sin_addr.s_addr, (char*)server_hostname->h_addr, server_hostname->h_length);
 		if (connect(fd, (struct sockaddr*)&server_addr, sizeof(server_addr)) < 0) {
 			log_cb(RETRO_LOG_ERROR, "Error connecting to server: %s\n", strerror(errno));
 			close(fd);


### PR DESCRIPTION
…t mode

Problem introduced by commit dca7f55d4f50036e9e37ab3c8f6957d0c68db918