### PR TITLE
fix sound on platforms where 'unsigned long' is only 32 bits wide

### DIFF
--- a/libgambatte/src/sound.cpp
+++ b/libgambatte/src/sound.cpp
@@ -103,10 +103,10 @@ namespace gambatte
       uint_least32_t *const buf = buffer_ + bufferPos_;
 
       std::memset(buf, 0, cycles * sizeof(uint_least32_t));
-      ch1_.update(buf, (soChVol_[0] * soVol_ * 0x1999999A) >> 32, cycles);
-      ch2_.update(buf, (soChVol_[1] * soVol_ * 0x1999999A) >> 32, cycles);
-      ch3_.update(buf, (soChVol_[2] * soVol_ * 0x1999999A) >> 32, cycles);
-      ch4_.update(buf, (soChVol_[3] * soVol_ * 0x1999999A) >> 32, cycles);
+      ch1_.update(buf, (soChVol_[0] * soVol_ * 0x1999999AULL) >> 32, cycles);
+      ch2_.update(buf, (soChVol_[1] * soVol_ * 0x1999999AULL) >> 32, cycles);
+      ch3_.update(buf, (soChVol_[2] * soVol_ * 0x1999999AULL) >> 32, cycles);
+      ch4_.update(buf, (soChVol_[3] * soVol_ * 0x1999999AULL) >> 32, cycles);
    }
 
    void PSG::generateSamples(unsigned long const cycleCounter, bool const doubleSpeed)


### PR DESCRIPTION
Commit 1d5f921d1846a2939b83334157b30dd7a34e80c8 introduced a bit shift
that is too wide on 32 bit platforms. This results in the volume of
all channels being set to zero in the internal mixer.

Problem observed on a Raspberry Pi Zero W, where the compiler also
complains:

libgambatte/src/sound.cpp:106:63:
  warning: right shift count >= width of type [-Wshift-count-overflow]
  ch1_.update(buf, (soChVol_[0] * soVol_ * 0x1999999A) >> 32, cycles);
                                                          ^~

Fix this problem by expanding the constant 0x1999999A to unsigned long long
via the 'ULL' suffix. This results in all values in the expression being
promoted to 'unsigned long long', which is 64 bit wide everywhere.