### PR TITLE
Ensure frame blending configuration is correctly reset in retro_deinit()

### DIFF
--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -513,6 +513,9 @@ static void deinit_frame_blending(void)
       free(video_buf_acc_b);
       video_buf_acc_b = NULL;
    }
+
+   frame_blend_type         = FRAME_BLEND_NONE;
+   frame_blend_response_set = false;
 }
 
 static void check_frame_blend_variable(void)


### PR DESCRIPTION
At present, the second time that content is loaded with the core on dynamic platforms, undefined behaviour can occur due to the fact that the interframe blending arrays are not correctly initialised. This is a previously hidden bug (which should never occur on dynamic platforms...), and it seems to be platform-dependent: the core has always functioned correctly in the past, and it still functions correctly on half my devices. It is likely that an OS (glibc) update has revealed the underlying issue...

This PR simply ensures that the interframe blending configuration is properly reset inside `retro_deinit()`. This 'forces' correct initialisation each time the core is loaded.