### PR TITLE
Prevent segfaults due to audio buffer overflows

### DIFF
--- a/libgambatte/include/gambatte.h
+++ b/libgambatte/include/gambatte.h
@@ -54,6 +54,8 @@ public:
 	  *
 	  * There are 35112 stereo sound samples in a video frame.
 	  * May run for uptil 2064 stereo samples too long.
+	  * EDIT: Due to internal emulator bugs, may in fact run for
+	  *       an arbitrary number of samples...
 	  * A stereo sample consists of two native endian 2s complement 16-bit PCM samples,
 	  * with the left sample preceding the right one. Usually casting soundBuf to/from
 	  * short* is OK and recommended. The reason for not using a short* in the interface
@@ -67,11 +69,12 @@ public:
 	  * @param videoBuf 160x144 RGB32 (native endian) video frame buffer or 0
 	  * @param pitch distance in number of pixels (not bytes) from the start of one line to the next in videoBuf.
 	  * @param soundBuf buffer with space >= samples + 2064
+	  * @param soundBufSize actual size of soundBuf buffer
 	  * @param samples in: number of stereo samples to produce, out: actual number of samples produced
 	  * @return sample number at which the video frame was produced. -1 means no frame was produced.
 	  */
 	long runFor(gambatte::video_pixel_t *videoBuf, int pitch,
-			gambatte::uint_least32_t *soundBuf, unsigned &samples);
+			gambatte::uint_least32_t *soundBuf, std::size_t soundBufSize, unsigned &samples);
 	
 	/** Reset to initial state.
 	  * Equivalent to reloading a ROM image, or turning a Game Boy Color off and on again.

--- a/libgambatte/src/cpu.h
+++ b/libgambatte/src/cpu.h
@@ -86,7 +86,7 @@ public:
 #if 0
 	bool loaded() const { return mem_.loaded(); }
 #endif
-	void setSoundBuffer(uint_least32_t *buf) { mem_.setSoundBuffer(buf); }
+	void setSoundBuffer(uint_least32_t *buf, std::size_t size) { mem_.setSoundBuffer(buf, size); }
 	std::size_t fillSoundBuffer() { return mem_.fillSoundBuffer(cycleCounter_); }
 	bool isCgb() const { return mem_.isCgb(); }
 

--- a/libgambatte/src/gambatte-memory.h
+++ b/libgambatte/src/gambatte-memory.h
@@ -120,7 +120,7 @@ public:
 	void setSerialIO(SerialIO* serial_io) { serial_io_ = serial_io; }
 #endif
 	void setEndtime(unsigned long cc, unsigned long inc);
-	void setSoundBuffer(uint_least32_t *buf) { psg_.setBuffer(buf); }
+	void setSoundBuffer(uint_least32_t *buf, std::size_t size) { psg_.setBuffer(buf, size); }
 	std::size_t fillSoundBuffer(unsigned long cc);
 
 	void setVideoBuffer(video_pixel_t *videoBuf, std::ptrdiff_t pitch) {

--- a/libgambatte/src/gambatte.cpp
+++ b/libgambatte/src/gambatte.cpp
@@ -43,10 +43,10 @@ GB::~GB() {
 }
 
 long GB::runFor(gambatte::video_pixel_t *const videoBuf, const int pitch,
-			gambatte::uint_least32_t *const soundBuf, unsigned &samples) {
+			gambatte::uint_least32_t *const soundBuf, std::size_t soundBufSize, unsigned &samples) {
 	
 	p_->cpu.setVideoBuffer(videoBuf, pitch);
-	p_->cpu.setSoundBuffer(soundBuf);
+	p_->cpu.setSoundBuffer(soundBuf, soundBufSize);
 	const long cyclesSinceBlit = p_->cpu.runFor(samples * 2);
 	samples = p_->cpu.fillSoundBuffer();
 	

--- a/libgambatte/src/sound.cpp
+++ b/libgambatte/src/sound.cpp
@@ -45,6 +45,7 @@ namespace gambatte
 
    PSG::PSG()
       :  buffer_(0)
+      ,  bufferSize_(0)
       ,  bufferPos_(0)
       ,  lastUpdate_(0)
       ,  soVol_(0)
@@ -96,7 +97,6 @@ namespace gambatte
    void PSG::accumulateChannels(const unsigned long cycles)
    {
       uint_least32_t *const buf = buffer_ + bufferPos_;
-
       std::memset(buf, 0, cycles * sizeof(uint_least32_t));
       ch1_.update(buf, soVol_, cycles);
       ch2_.update(buf, soVol_, cycles);
@@ -106,7 +106,11 @@ namespace gambatte
 
    void PSG::generateSamples(unsigned long const cycleCounter, bool const doubleSpeed)
    {
-      unsigned long const cycles = (cycleCounter - lastUpdate_) >> (1 + doubleSpeed);
+      unsigned long cycles = (cycleCounter - lastUpdate_) >> (1 + doubleSpeed);
+
+      if (cycles + bufferPos_ > bufferSize_)
+         cycles = (bufferSize_ > bufferPos_) ? (bufferSize_ - bufferPos_) : 0;
+
       lastUpdate_ += cycles << (1 + doubleSpeed);
 
       if (cycles)

--- a/libgambatte/src/sound.h
+++ b/libgambatte/src/sound.h
@@ -41,7 +41,7 @@ public:
 	void generateSamples(unsigned long cycleCounter, bool doubleSpeed);
 	void resetCounter(unsigned long newCc, unsigned long oldCc, bool doubleSpeed);
    std::size_t fillBuffer();
-	void setBuffer(uint_least32_t *buf) { buffer_ = buf; bufferPos_ = 0; }
+	void setBuffer(uint_least32_t *buf, std::size_t size) { buffer_ = buf; bufferSize_ = size; bufferPos_ = 0; }
 
 	bool isEnabled() const { return enabled_; }
 	void setEnabled(bool value) { enabled_ = value; }
@@ -80,6 +80,7 @@ private:
 	Channel3 ch3_;
 	Channel4 ch4_;
 	uint_least32_t *buffer_;
+	std::size_t bufferSize_;
 	std::size_t bufferPos_;
 	unsigned long lastUpdate_;
 	unsigned long soVol_;


### PR DESCRIPTION
While testing #183, I noticed that at least two GBC games cause Gambatte to generate a segfault (`1942` and `Alone in the Dark`). This happens because the `GB::runFor()` function has an inaccurate description:

- It accepts an audio buffer and a requested number of samples, claiming that up to `(samples + 2064)` samples will actually be generated
- The audio buffer is therefore sized accordingly
- In certain edge cases, `GB::runFor()` in fact generates an arbitrary number of samples - which overflow the supplied audio buffer and cause a segfault

This PR simply makes the audio handling code aware of the input buffer size, and 'clips' the generated output in the event that an overflow would occur. There are no longer any segfaults, and both `1942` and `Alone in the Dark` now run correctly.