### PR TITLE
[DRAFT] RS90 Support

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -344,6 +344,18 @@ else ifeq ($(platform), emscripten)
    TARGET := $(TARGET_NAME)_libretro_$(platform).bc
    STATIC_LINKING = 1
 
+# RS90
+else ifeq ($(platform), rs90)
+   TARGET := $(TARGET_NAME)_libretro.so
+   CC = /opt/rs90-toolchain/usr/bin/mipsel-linux-gcc
+   CXX = /opt/rs90-toolchain/usr/bin/mipsel-linux-g++
+   AR = /opt/rs90-toolchain/usr/bin/mipsel-linux-ar
+   fpic := -fPIC
+   SHARED := -shared -Wl,-version-script=$(version_script)
+   PLATFORM_DEFINES := -DCC_RESAMPLER -DCC_RESAMPLER_NO_HIGHPASS
+   CFLAGS += -fomit-frame-pointer -ffast-math -march=mips32 -mtune=mips32
+   CXXFLAGS += $(CFLAGS)
+
 # GCW0
 else ifeq ($(platform), gcw0)
    TARGET := $(TARGET_NAME)_libretro.so


### PR DESCRIPTION
This PR adds support for the rs90. The device is extremely similar to gcw0.

The differences are:

* Uses a different toolchain
* mips32 only (not mips32r2)
* No hard float

Because of these changes, it needs to be recompiled.

PR to actually add support in RetroArch: https://github.com/libretro/RetroArch/pull/12592

Don't merge yet. There's compiler flags in there which should be removed, and broken white space.