### PR TITLE
Remove unused variable in libretro_core_options.h

### DIFF
--- a/libgambatte/libretro/libretro_core_options.h
+++ b/libgambatte/libretro/libretro_core_options.h
@@ -1223,8 +1223,6 @@ static INLINE void libretro_set_core_options(retro_environment_t environ_cb,
                /* Build values string */
                if (num_values > 0)
                {
-                  size_t j;
-
                   buf_len += num_values - 1;
                   buf_len += strlen(desc);
 


### PR DESCRIPTION
This trivial PR just removes an unused variable from the libretro_core_options.h file (overlooked previously, since the compiler did not generate a warning....)