### PR TITLE
Show commit hash in core version

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -58,6 +58,11 @@ TARGET_NAME := gambatte
 version_script = libgambatte/libretro/link.T
 core_installdir := $(prefix)/lib
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+   CXXFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 # Unix
 ifneq (,$(findstring unix,$(platform)))
    TARGET := $(TARGET_NAME)_libretro.so

--- a/libgambatte/libretro/jni/Android.mk
+++ b/libgambatte/libretro/jni/Android.mk
@@ -14,6 +14,11 @@ ifeq ($(HAVE_NETWORK),1)
   COREFLAGS += -DHAVE_NETWORK
 endif
 
+GIT_VERSION := " $(shell git rev-parse --short HEAD || echo unknown)"
+ifneq ($(GIT_VERSION)," unknown")
+  COREFLAGS += -DGIT_VERSION=\"$(GIT_VERSION)\"
+endif
+
 include $(CLEAR_VARS)
 LOCAL_MODULE    := retro
 LOCAL_SRC_FILES := $(SOURCES_CXX) $(SOURCES_C)

--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -869,10 +869,13 @@ static blipper_t *resampler_r;
 void retro_get_system_info(struct retro_system_info *info)
 {
    info->library_name = "Gambatte";
+#ifndef GIT_VERSION
+#define GIT_VERSION ""
+#endif
 #ifdef HAVE_NETWORK
-   info->library_version = "v0.5.0-netlink";
+   info->library_version = "v0.5.0-netlink" GIT_VERSION;
 #else
-   info->library_version = "v0.5.0";
+   info->library_version = "v0.5.0" GIT_VERSION;
 #endif
    info->need_fullpath = false;
    info->block_extract = false;


### PR DESCRIPTION
This minor PR extends the library_version string and updates the corresponding makefiles, so that the core version now displays the hash of the latest commit right after the emulator version string, which is currently hard-coded (right now it is either 0.5.0 or 0.5.0-netlink for Gambatte).