### PR TITLE
Enable switching of internal palette via RetroPad L/R

### DIFF
--- a/libgambatte/libretro-common/include/libretro.h
+++ b/libgambatte/libretro-common/include/libretro.h
@@ -1722,6 +1722,31 @@ enum retro_mod
                                             * Must be called in retro_set_environment().
                                             */
 
+#define RETRO_ENVIRONMENT_SET_VARIABLE 70
+                                           /* const struct retro_variable * --
+                                            * Allows an implementation to notify the frontend
+                                            * that a core option value has changed.
+                                            *
+                                            * retro_variable::key and retro_variable::value
+                                            * must match strings that have been set previously
+                                            * via one of the following:
+                                            *
+                                            * - RETRO_ENVIRONMENT_SET_VARIABLES
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_INTL
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2
+                                            * - RETRO_ENVIRONMENT_SET_CORE_OPTIONS_V2_INTL
+                                            *
+                                            * After changing a core option value via this
+                                            * callback, RETRO_ENVIRONMENT_GET_VARIABLE_UPDATE
+                                            * will return true.
+                                            *
+                                            * If data is NULL, no changes will be registered
+                                            * and the callback will return true; an
+                                            * implementation may therefore pass NULL in order
+                                            * to test whether the callback is supported.
+                                            */
+
 /* VFS functionality */
 
 /* File paths:


### PR DESCRIPTION
As reported in #182, testing the various internal palettes by selecting them via the menu is incredibly laborious. This PR adds the ability to switch to the next/previous internal palette via the RetroPad R/L buttons while content is running:

![screen_record__2021_10_06__17_11_02](https://user-images.githubusercontent.com/38211560/136244454-945e0b6e-070f-4947-8067-22f971d00223.gif)

This PR serves as a test case for the new `RETRO_ENVIRONMENT_SET_VARIABLE` callback, and the functionality here is only enabled when using frontends that support this callback.

Closes #182