### PR TITLE
Remove dangerous compilation flag on the Pi platforms.

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -75,7 +75,7 @@ ifneq (,$(findstring unix,$(platform)))
 
    # Raspberry Pi
    ifneq (,$(findstring rpi,$(platform)))
-      CFLAGS += -fomit-frame-pointer -ffast-math
+      CFLAGS += -fomit-frame-pointer
       CXXFLAGS += $(CFLAGS)
       ifneq (,$(findstring rpi1,$(platform)))
          CFLAGS += -march=armv6j -mfpu=vfp -mfloat-abi=hard -marm


### PR DESCRIPTION
Previously I added the `-ffast-math` flag to everything, but some cores have shown unexpected results with it. Better remove it. Some optimization levels activate it implicitly: that's better than doing it by hand.