### PR TITLE
Fix loading of custom palettes with CRLF line terminators

### DIFF
--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -1651,6 +1651,12 @@ static void load_custom_palette(void)
       if (!line)
          break;
 
+      /* Remove any leading/trailing whitespace
+       * > Additionally handles 'leftovers' from
+       *   CRLF line terminators if palette file
+       *   happens to be in DOS format */
+      string_trim_whitespace(line);
+
       if (string_is_empty(line) || /* Skip empty lines */
           (*line == '[') ||        /* Skip ini sections */
           (*line == ';'))          /* Skip ini comments */


### PR DESCRIPTION
As reported in #207, the core can only load custom palette files in UNIX format. This trivial PR fixes the issue, such that files with CRLF line terminators can now be loaded successfully.

Closes #207.