### PR TITLE
Sync weekly instead of daily

### DIFF
--- a/.github/workflows/crowdin_translate.yml
+++ b/.github/workflows/crowdin_translate.yml
@@ -4,7 +4,7 @@ name: Crowdin Translation Integration
 
 on:
   schedule:
-    - cron: '50 10 * * *'  # 10:50 AM, UTC
+    - cron: '50 10 * * 5'  # Friday at 10:50 AM, UTC
 
 jobs:
   create_intl_file:


### PR DESCRIPTION
Sets the Crowdin sync to happen weekly, rather than daily.
Will create fewer commits (& error messages due to empty commit).