### PR TITLE
Let GCC chose the proper march and mcpu flags for each Pi model.

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -73,24 +73,10 @@ ifneq (,$(findstring unix,$(platform)))
    LDFLAGS += -lnetwork -lroot
    endif
 
-   # Raspberry Pi
-   ifneq (,$(findstring rpi,$(platform)))
-      CFLAGS += -fomit-frame-pointer
-      CXXFLAGS += $(CFLAGS)
-      ifneq (,$(findstring rpi1,$(platform)))
-         CFLAGS += -march=armv6j -mfpu=vfp -mfloat-abi=hard -marm
-      else ifneq (,$(findstring rpi2,$(platform)))
-         CFLAGS += -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard -marm
-      else ifneq (,$(findstring rpi3,$(platform)))
-         ifneq (,$(findstring rpi3_64,$(platform)))
-            CFLAGS += -mcpu=cortex-a53 -mtune=cortex-a53
-         else
-            CFLAGS += -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard -marm
-         endif
-      else ifneq (,$(findstring rpi4,$(platform)))
-         CFLAGS += -mcpu=cortex-a72 -mtune=cortex-a72
-      endif
-   endif
+# Raspberry Pi: Modern GCC provides the proper flags for each model.
+ifneq (,$(findstring rpi,$(platform)))
+  FLAGS += -DARM -march=native -mcpu=native -ftree-vectorize -pipe -fomit-frame-pointer
+endif
 
 # Classic Platforms ####################
 # Platform affix = classic_<ISA>_<µARCH>


### PR DESCRIPTION
Modern GCC provides the right flags for each Pi model, no need to have a chunk of ifeqs for that anymore.