### PR TITLE
Fix build problems due to removal of the Hebrew localisation

### DIFF
--- a/.github/workflows/crowdin_prep.yml
+++ b/.github/workflows/crowdin_prep.yml
@@ -15,15 +15,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: 18
+          distribution: zulu
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Upload Source
         shell: bash

--- a/.github/workflows/crowdin_translate.yml
+++ b/.github/workflows/crowdin_translate.yml
@@ -11,15 +11,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Setup Java JDK
-        uses: actions/setup-java@v1
+        uses: actions/setup-java@v3
         with:
-          java-version: 1.8
+          java-version: 18
+          distribution: zulu
 
       - name: Setup Python
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
 
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
           persist-credentials: false # otherwise, the token used is the GITHUB_TOKEN, instead of your personal access token.
           fetch-depth: 0 # otherwise, there would be errors pushing refs to the destination repository.

--- a/libgambatte/libretro/libretro_core_options_intl.h
+++ b/libgambatte/libretro/libretro_core_options_intl.h
@@ -37,6 +37,12 @@ extern "C" {
  * Core Option Definitions
  ********************************
 */
+struct retro_core_option_v2_category option_cats_he[] = {};
+struct retro_core_option_v2_definition option_defs_he[] = {};
+struct retro_core_options_v2 options_he = {
+   option_cats_he,
+   option_defs_he
+};
 /* RETRO_LANGUAGE_AR */
 
 #define CATEGORY_GB_LINK_LABEL_AR NULL


### PR DESCRIPTION
The Hebrew language was erroneously removed on Crowdin - right before the sync script ran. This lead to build errors, as some requires variables suddenly became undefined. This PR replaces these variables with dummies to enable building the core again.