### PR TITLE
Makefile fix to enable build for "unix-armv7-hardfloat-neon"

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -98,7 +98,7 @@ ifneq (,$(findstring unix,$(platform)))
 
 # (armv7 a7, hard point, neon based) ### 
 # NESC, SNESC, C64 mini 
-else ifeq ($(platform), classic_armv7_a7)
+else ifeq ($(platform),$(filter $(platform),classic_armv7_a7 unix-armv7-hardfloat-neon))
 	TARGET := $(TARGET_NAME)_libretro.so
 	fpic := -fPIC
     SHARED := -shared -Wl,--version-script=$(version_script)  -Wl,--no-undefined -fPIC


### PR DESCRIPTION
port from tgbdual-libretro
https://github.com/libretro/tgbdual-libretro/commit/11d4c6e21be51f07ac9e797ff466ae0914497d12