### PR TITLE
Small tweak to the color correction

### DIFF
--- a/libgambatte/libretro/libretro.cpp
+++ b/libgambatte/libretro/libretro.cpp
@@ -2410,7 +2410,6 @@ static void check_variables(bool startup)
          break;
       default: // GB_COLORIZATION_DISABLED
          gbc_bios_palette = findGbcDirPal("GBC - Grayscale");
-         isGbcPalette = true;
          break;
    }
    


### PR DESCRIPTION
Currently when you have "GB Colorization" OFF and "Color Correction" set to "GBC Only" the core will still perform the color correction for GB games.

This is incorrect according to the option description:

> 'GBC Only' ensures that correction will only be applied when playing Game Boy Color games, or when using a Game Boy Color palette to colorize a Game Boy game.

So let's keep that `isGbcPalette` bool false.

Closes #254