### PR TITLE
Enable netlink on windows

### DIFF
--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -528,6 +528,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 	TARGET := $(TARGET_NAME)_libretro.dll
 	PSS_STYLE :=2
 	LDFLAGS += -DLL
+   HAVE_NETWORK=1
 
 # Windows MSVC 2010 x64
 else ifeq ($(platform), windows_msvc2010_x64)

--- a/Makefile.libretro
+++ b/Makefile.libretro
@@ -448,7 +448,7 @@ else ifneq (,$(findstring windows_msvc2017,$(platform)))
 		WinPartition = desktop
         MSVC2017CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_DESKTOP_APP
 		LDFLAGS += -MANIFEST -LTCG:incremental -NXCOMPAT -DYNAMICBASE -DEBUG -OPT:REF -INCREMENTAL:NO -SUBSYSTEM:WINDOWS -MANIFESTUAC:"level='asInvoker' uiAccess='false'" -OPT:ICF -ERRORREPORT:PROMPT -NOLOGO -TLBID:1
-		LIBS += kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib
+		LIBS += kernel32.lib user32.lib gdi32.lib winspool.lib comdlg32.lib advapi32.lib ws2_32.lib
 	else ifneq (,$(findstring uwp,$(PlatformSuffix)))
 		WinPartition = uwp
 		MSVC2017CompileFlags = -DWINAPI_FAMILY=WINAPI_FAMILY_APP -D_WINDLL -D_UNICODE -DUNICODE -D__WRL_NO_DEFAULT_LIB__ -EHsc

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,7 +13,11 @@ configuration:
   - release
 
 platform:
+  - windows_msvc2017_uwp_x64
+  - windows_msvc2017_uwp_x86
+  - windows_msvc2017_uwp_arm
   - windows_msvc2017_desktop_x64
+  - windows_msvc2017_desktop_x86
 
 init:
   - set Path=C:\msys64\usr\bin;%Path%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -14,7 +14,6 @@ configuration:
 
 platform:
   - windows_msvc2017_desktop_x64
-  - windows_msvc2017_desktop_x86
 
 init:
   - set Path=C:\msys64\usr\bin;%Path%

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,9 +13,6 @@ configuration:
   - release
 
 platform:
-  - windows_msvc2017_uwp_x64
-  - windows_msvc2017_uwp_x86
-  - windows_msvc2017_uwp_arm
   - windows_msvc2017_desktop_x64
   - windows_msvc2017_desktop_x86
 

--- a/libgambatte/libretro/net_serial.cpp
+++ b/libgambatte/libretro/net_serial.cpp
@@ -3,14 +3,14 @@
 #include "gambatte_log.h"
 #include <stdlib.h>
 #include <string.h>
-#include <unistd.h>
-#include <errno.h>
-#include <sys/types.h>
 #ifdef _WIN32
 #include <winsock2.h>
 #include <ws2tcpip.h>
 #include <winbase.h>
 #else
+#include <unistd.h>
+#include <errno.h>
+#include <sys/types.h>
 #include <sys/socket.h>
 #include <sys/ioctl.h>
 #include <netinet/in.h>

--- a/libgambatte/libretro/net_serial.cpp
+++ b/libgambatte/libretro/net_serial.cpp
@@ -111,7 +111,7 @@ bool NetSerial::startServerSocket()
 #ifdef _WIN32
 			LPSTR lpErrorMessage;
 			FormatMessageA(FORMAT_MESSAGE_FROM_SYSTEM | FORMAT_MESSAGE_ALLOCATE_BUFFER, NULL, WSAGetLastError(), MAKELANGID(LANG_NEUTRAL, SUBLANG_DEFAULT), (LPSTR) &lpErrorMessage, 0, NULL);
-			gambatte_log(RETRO_LOG_ERROR, "Error opening socket: %s\n", strerror(errno));
+			gambatte_log(RETRO_LOG_ERROR, "Error opening socket: %s\n", lpErrorMessage);
 			LocalFree(lpErrorMessage);
 #else
 			gambatte_log(RETRO_LOG_ERROR, "Error opening socket: %s\n", strerror(errno));

--- a/libgambatte/libretro/net_serial.cpp
+++ b/libgambatte/libretro/net_serial.cpp
@@ -17,6 +17,11 @@
 #include <netdb.h>
 #endif
 
+#ifdef _WIN32
+#define close closesocket
+#define ioctl ioctlsocket
+#endif
+
 NetSerial::NetSerial()
 : is_stopped_(true)
 , is_server_(false)
@@ -27,7 +32,9 @@ NetSerial::NetSerial()
 , lastConnectAttempt_(0)
 {
 #ifdef _WIN32
-	wsaStartupStatus = WSAStartup(MAKEWORD(2, 2), &wsaData);
+	//wsaStartupStatus = WSAStartup(MAKEWORD(2, 2), &wsaData);
+	WSADATA data = {};
+	WSAStartup(MAKEWORD(2, 2), &data);
 #endif
 }
 
@@ -260,11 +267,7 @@ bool NetSerial::check(unsigned char out, unsigned char& in, bool& fastCgb)
 			return false;
 		}
 	}
-#ifdef _WIN32
-   if (ioctlsocket(sockfd_, FIONREAD, &bytes_avail) < 0)
-#else
 	if (ioctl(sockfd_, FIONREAD, &bytes_avail) < 0)
-#endif
    {
 		gambatte_log(RETRO_LOG_ERROR, "IOCTL Failed: %s\n", strerror(errno));
 		return false;

--- a/libgambatte/libretro/net_serial.h
+++ b/libgambatte/libretro/net_serial.h
@@ -6,6 +6,10 @@
 #include <sys/select.h>
 #endif
 
+#if _WIN32
+#include <winsock2.h>
+#endif
+
 #include <gambatte.h>
 #include <time.h>
 
@@ -36,6 +40,11 @@ class NetSerial : public gambatte::SerialIO
 		int sockfd_;
 
 		clock_t lastConnectAttempt_;
+
+#ifdef __WIN32
+		WSADATA wsaData;
+		int wsaStartupStatus;
+#endif
 };
 
 #endif


### PR DESCRIPTION
Fixes #201 

Add WSAStartup call and wrap ioctl and close calls with their win32 equivalents. Minimal logging to check for initial socket() failure.

Tested on win10 x64 and win11 x64 with retroarch