### PR TITLE
'Magnemite Cry' and others noise channel fix

### DIFF
--- a/libgambatte/src/sound/channel4.cpp
+++ b/libgambatte/src/sound/channel4.cpp
@@ -92,6 +92,7 @@ inline void Channel4::Lfsr::event() {
 void Channel4::Lfsr::nr3Change(unsigned newNr3, unsigned long cc) {
 	updateBackupCounter(cc);
 	nr3_ = newNr3;
+	counter_ = cc;
 }
 
 void Channel4::Lfsr::nr4Init(unsigned long cc) {


### PR DESCRIPTION
Backport this change from gambatte-speedrun to reset LSFR event counter to current cycle when NR43 changes to avoid delayed noise channel updates.  In addition to the below this fixes the Pokemon Magnemite Cry issue and other similar issues.

https://github.com/pokemon-speedrunning/gambatte-speedrun/pull/27 Minor fix: Fix writes to $FF22 (NR43) to reset counter_. This was uncovered since the sound effect for taking damage in Mickey appeared to be skipped in all versions of Gambatte. Debugging showed the noise channel playing a single sample of the effect, then not producing sound until reaching counter_ ~0.5 seconds later (after an $E7 write, implying ~2 Hz sound). Resetting counter_ on $FF22 writes resulted in the proper behavior of playing the full sound effect.