### PR TITLE
c++17 compatible

### DIFF
--- a/libgambatte/src/mem/cartridge.h
+++ b/libgambatte/src/mem/cartridge.h
@@ -159,7 +159,11 @@ namespace gambatte
          Rtc rtc_;
          HuC3Chip huc3_;
 
+#if __cplusplus >= 201103L
+         std::unique_ptr<Mbc> mbc;
+#else
          std::auto_ptr<Mbc> mbc;
+#endif
 
          std::vector<AddrData> ggUndoList_;
 

--- a/libgambatte/src/statesaver.cpp
+++ b/libgambatte/src/statesaver.cpp
@@ -269,12 +269,12 @@ public:
 	SaverList();
 	const_iterator begin() const { return list.begin(); }
 	const_iterator end() const { return list.end(); }
-	unsigned maxLabelsize() const { return maxLabelsize_; }
+	unsigned char maxLabelsize() const { return maxLabelsize_; }
 };
 
 static void pushSaver(SaverList::list_t &list, const char *label,
 		void (*save)(omemstream &file, const SaveState &state),
-		void (*load)(imemstream &file, SaveState &state), unsigned labelsize) {
+		void (*load)(imemstream &file, SaveState &state), unsigned char labelsize) {
 	const Saver saver = { label, save, load, labelsize };
 	list.push_back(saver);
 }


### PR DESCRIPTION
Hello, this 2 changes allow this core to build with c++17 (where auto_ptr was removed) and later, c++98 is still supported.